### PR TITLE
switch from astyle to clang-format

### DIFF
--- a/NanoCORE/ElectronSelections.cc
+++ b/NanoCORE/ElectronSelections.cc
@@ -74,57 +74,45 @@ bool ifpassElectronMVAID(int iel, string id_name) {
     switch (id_level) {
     case (1):
         if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) < 0.8) {
-            if (Electron_mvaFall17V1noIso()[iel] <=
-                electronMvacut(0.2, 0.68, 0.2, Electron_pt()[iel]))
-                return false;
+            if (Electron_mvaFall17V1noIso()[iel] <= electronMvacut(0.2, 0.68, 0.2, Electron_pt()[iel])) return false;
         }
         if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) >= 0.8 &&
             fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) <= 1.479) {
-            if (Electron_mvaFall17V1noIso()[iel] <=
-                electronMvacut(0.1, 0.475, 0.1, Electron_pt()[iel]))
-                return false;
+            if (Electron_mvaFall17V1noIso()[iel] <= electronMvacut(0.1, 0.475, 0.1, Electron_pt()[iel])) return false;
         }
         if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) > 1.479) {
-            if (Electron_mvaFall17V1noIso()[iel] <=
-                electronMvacut(-0.1, 0.32, -0.1, Electron_pt()[iel]))
-                return false;
+            if (Electron_mvaFall17V1noIso()[iel] <= electronMvacut(-0.1, 0.32, -0.1, Electron_pt()[iel])) return false;
         }
         return true;
         break;
     case (2):
         if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) < 0.8) {
-            if (Electron_mvaFall17V1noIso()[iel] <=
-                electronMvacut(-0.788, -0.64, 0.488, Electron_pt()[iel]))
+            if (Electron_mvaFall17V1noIso()[iel] <= electronMvacut(-0.788, -0.64, 0.488, Electron_pt()[iel]))
                 return false;
         }
         if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) >= 0.8 &&
             fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) <= 1.479) {
-            if (Electron_mvaFall17V1noIso()[iel] <=
-                electronMvacut(-0.85, -0.775, -0.045, Electron_pt()[iel]))
+            if (Electron_mvaFall17V1noIso()[iel] <= electronMvacut(-0.85, -0.775, -0.045, Electron_pt()[iel]))
                 return false;
         }
         if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) > 1.479) {
-            if (Electron_mvaFall17V1noIso()[iel] <=
-                electronMvacut(-0.81, -0.733, 0.176, Electron_pt()[iel]))
+            if (Electron_mvaFall17V1noIso()[iel] <= electronMvacut(-0.81, -0.733, 0.176, Electron_pt()[iel]))
                 return false;
         }
         return true;
         break;
     case (3):
         if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) < 0.8) {
-            if (Electron_mvaFall17V1noIso()[iel] <=
-                electronMvacut(-0.93, -0.887, -0.135, Electron_pt()[iel]))
+            if (Electron_mvaFall17V1noIso()[iel] <= electronMvacut(-0.93, -0.887, -0.135, Electron_pt()[iel]))
                 return false;
         }
         if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) >= 0.8 &&
             fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) <= 1.479) {
-            if (Electron_mvaFall17V1noIso()[iel] <=
-                electronMvacut(-0.93, -0.89, -0.417, Electron_pt()[iel]))
+            if (Electron_mvaFall17V1noIso()[iel] <= electronMvacut(-0.93, -0.89, -0.417, Electron_pt()[iel]))
                 return false;
         }
         if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) > 1.479) {
-            if (Electron_mvaFall17V1noIso()[iel] <=
-                electronMvacut(-0.942, -0.91, -0.470, Electron_pt()[iel]))
+            if (Electron_mvaFall17V1noIso()[iel] <= electronMvacut(-0.942, -0.91, -0.470, Electron_pt()[iel]))
                 return false;
         }
         return true;

--- a/NanoCORE/ElectronSelections.cc
+++ b/NanoCORE/ElectronSelections.cc
@@ -3,294 +3,152 @@
 
 using namespace tas;
 
-bool electronIDVBS(int iel, string id_name)
-{
+bool electronIDVBS(int iel, string id_name) {
     int id_level;
     if (id_name == "2017_tight")
-    {
         id_level = 1;
-    }
     else if (id_name == "2017 loose")
-    {
         id_level = 2;
-    }
-    else
-    {
+    else {
         cout << "wrong input id name" << endl;
         return 0;
     }
-    switch (id_level)
-    {
-        case (1):
-            if (Electron_pt()[iel] <= 10)
-            {
-                return false;
-            }
-            if (!isTriggerSafenoIso_v3(iel))
-            {
-                return false;
-            }
-            if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) > 2.5)
-            {
-                return false;
-            }
-            if (!Electron_convVeto()[iel])
-            {
-                return false;
-            }
-            if ((int)(Electron_lostHits()[iel]) > 1)
-            {
-                return false;
-            }
-            if (fabs(Electron_dxy()[iel]) > 0.05)
-            {
-                return false;
-            }
-            if (fabs(Electron_dz()[iel]) >= 0.1)
-            {
-                return false;
-            }
-            if (!ifpassElectronMVAID(iel, "2017_veto_noiso"))
-            {
-                return false;
-            }
-            if ((int)(Electron_lostHits()[iel]) > 0)
-            {
-                return false;    //SS_innerlayers
-            }
-            if (Electron_tightCharge()[iel] == 0 || Electron_tightCharge()[iel] == 1)
-            {
-                return false;
-            }
-            if (fabs(Electron_sip3d()[iel]) > 4)
-            {
-                return false;
-            }
-            if (!ifpassElectronMVAID(iel, "2017_medium"))
-            {
-                return false;
-            }
-            if (!passElectronIso(0.07, 0.78, 8.0, iel))
-            {
-                return false;
-            }
-            return true;
-            break;
-        case (2):
-            if (Electron_pt()[iel] <= 10)
-            {
-                return false;
-            }
-            if (!isTriggerSafenoIso_v3(iel))
-            {
-                return false;
-            }
-            if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) > 2.5)
-            {
-                return false;
-            }
-            if (!Electron_convVeto()[iel])
-            {
-                return false;
-            }
-            if ((int)(Electron_lostHits()[iel]) > 1)
-            {
-                return false;
-            }
-            if (fabs(Electron_dxy()[iel]) > 0.05)
-            {
-                return false;
-            }
-            if (fabs(Electron_dz()[iel]) >= 0.1)
-            {
-                return false;
-            }
-            if (!ifpassElectronMVAID(iel, "2017_veto_noiso"))
-            {
-                return false;
-            }
-            if ((int)(Electron_lostHits()[iel]) > 0)
-            {
-                return false;    //SS_innerlayers
-            }
-            if (Electron_tightCharge()[iel] == 0 || Electron_tightCharge()[iel] == 1)
-            {
-                return false;
-            }
-            if (fabs(Electron_sip3d()[iel]) >= 4)
-            {
-                return false;
-            }
-            if (!ifpassElectronMVAID(iel, "2017SS_fo_looseMVA_noiso_v6"))
-            {
-                return false;
-            }
-            if (Electron_miniPFRelIso_all()[iel] >= 0.4)
-            {
-                return false;
-            }
-            return true;
-            break;
+    switch (id_level) {
+    case (1):
+        if (Electron_pt()[iel] <= 10) return false;
+        if (!isTriggerSafenoIso_v3(iel)) return false;
+        if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) > 2.5) return false;
+        if (!Electron_convVeto()[iel]) return false;
+        if ((int)(Electron_lostHits()[iel]) > 1) return false;
+        if (fabs(Electron_dxy()[iel]) > 0.05) return false;
+        if (fabs(Electron_dz()[iel]) >= 0.1) return false;
+        if (!ifpassElectronMVAID(iel, "2017_veto_noiso")) return false;
+        if ((int)(Electron_lostHits()[iel]) > 0) return false; // SS_innerlayers
+        if (Electron_tightCharge()[iel] == 0 || Electron_tightCharge()[iel] == 1) return false;
+        if (fabs(Electron_sip3d()[iel]) > 4) return false;
+        if (!ifpassElectronMVAID(iel, "2017_medium")) return false;
+        if (!passElectronIso(0.07, 0.78, 8.0, iel)) return false;
+        return true;
+        break;
+    case (2):
+        if (Electron_pt()[iel] <= 10) return false;
+        if (!isTriggerSafenoIso_v3(iel)) return false;
+        if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) > 2.5) return false;
+        if (!Electron_convVeto()[iel]) return false;
+        if ((int)(Electron_lostHits()[iel]) > 1) return false;
+        if (fabs(Electron_dxy()[iel]) > 0.05) return false;
+        if (fabs(Electron_dz()[iel]) >= 0.1) return false;
+        if (!ifpassElectronMVAID(iel, "2017_veto_noiso")) return false;
+        if ((int)(Electron_lostHits()[iel]) > 0) return false; // SS_innerlayers
+        if (Electron_tightCharge()[iel] == 0 || Electron_tightCharge()[iel] == 1) return false;
+        if (fabs(Electron_sip3d()[iel]) >= 4) return false;
+        if (!ifpassElectronMVAID(iel, "2017SS_fo_looseMVA_noiso_v6")) return false;
+        if (Electron_miniPFRelIso_all()[iel] >= 0.4) return false;
+        return true;
+        break;
     }
     cout << "Error in ElectronSelection.C : should not see this message!!!!!!!" << endl;
     return 0;
 }
 
-float electronMvacut(float A, float B, float C, float pt)
-{
-    if (pt < 10)
-    {
-        return C;
-    }
+float electronMvacut(float A, float B, float C, float pt) {
+    if (pt < 10) return C;
     if (pt > 25)
-    {
         return B;
-    }
     else
-    {
         return (A + (B - A) / 15 * (pt - 10));
-    }
 }
 
-bool ifpassElectronMVAID(int iel, string id_name)
-{
+bool ifpassElectronMVAID(int iel, string id_name) {
     int id_level;
     if (id_name == "2017_medium")
-    {
         id_level = 1;
-    }
     else if (id_name == "2017_veto_noiso")
-    {
         id_level = 2;
-    }
     else if (id_name == "2017SS_fo_looseMVA_noiso_v6")
-    {
         id_level = 3;
-    }
-    else
-    {
+    else {
         cout << "wrong input id name from ElectronSelection.C!!!!!" << endl;
         return 0;
     }
-    switch (id_level)
-    {
-        case (1):
-            if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) < 0.8)
-            {
-                if (Electron_mvaFall17V1noIso()[iel] <= electronMvacut(0.2, 0.68, 0.2, Electron_pt()[iel]))
-                {
-                    return false;
-                }
-            }
-            if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) >= 0.8 && fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) <= 1.479)
-            {
-                if (Electron_mvaFall17V1noIso()[iel] <= electronMvacut(0.1, 0.475, 0.1, Electron_pt()[iel]))
-                {
-                    return false;
-                }
-            }
-            if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) > 1.479)
-            {
-                if (Electron_mvaFall17V1noIso()[iel] <= electronMvacut(-0.1, 0.32, -0.1, Electron_pt()[iel]))
-                {
-                    return false;
-                }
-            }
-            return true;
-            break;
-        case (2):
-            if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) < 0.8)
-            {
-                if (Electron_mvaFall17V1noIso()[iel] <= electronMvacut(-0.788, -0.64, 0.488, Electron_pt()[iel]))
-                {
-                    return false;
-                }
-            }
-            if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) >= 0.8 && fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) <= 1.479)
-            {
-                if (Electron_mvaFall17V1noIso()[iel] <= electronMvacut(-0.85, -0.775, -0.045, Electron_pt()[iel]))
-                {
-                    return false;
-                }
-            }
-            if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) > 1.479)
-            {
-                if (Electron_mvaFall17V1noIso()[iel] <= electronMvacut(-0.81, -0.733, 0.176, Electron_pt()[iel]))
-                {
-                    return false;
-                }
-            }
-            return true;
-            break;
-        case (3):
-            if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) < 0.8)
-            {
-                if (Electron_mvaFall17V1noIso()[iel] <= electronMvacut(-0.93, -0.887, -0.135, Electron_pt()[iel]))
-                {
-                    return false;
-                }
-            }
-            if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) >= 0.8 && fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) <= 1.479)
-            {
-                if (Electron_mvaFall17V1noIso()[iel] <= electronMvacut(-0.93, -0.89, -0.417, Electron_pt()[iel]))
-                {
-                    return false;
-                }
-            }
-            if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) > 1.479)
-            {
-                if (Electron_mvaFall17V1noIso()[iel] <= electronMvacut(-0.942, -0.91, -0.470, Electron_pt()[iel]))
-                {
-                    return false;
-                }
-            }
-            return true;
-            break;
+    switch (id_level) {
+    case (1):
+        if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) < 0.8) {
+            if (Electron_mvaFall17V1noIso()[iel] <=
+                electronMvacut(0.2, 0.68, 0.2, Electron_pt()[iel]))
+                return false;
+        }
+        if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) >= 0.8 &&
+            fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) <= 1.479) {
+            if (Electron_mvaFall17V1noIso()[iel] <=
+                electronMvacut(0.1, 0.475, 0.1, Electron_pt()[iel]))
+                return false;
+        }
+        if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) > 1.479) {
+            if (Electron_mvaFall17V1noIso()[iel] <=
+                electronMvacut(-0.1, 0.32, -0.1, Electron_pt()[iel]))
+                return false;
+        }
+        return true;
+        break;
+    case (2):
+        if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) < 0.8) {
+            if (Electron_mvaFall17V1noIso()[iel] <=
+                electronMvacut(-0.788, -0.64, 0.488, Electron_pt()[iel]))
+                return false;
+        }
+        if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) >= 0.8 &&
+            fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) <= 1.479) {
+            if (Electron_mvaFall17V1noIso()[iel] <=
+                electronMvacut(-0.85, -0.775, -0.045, Electron_pt()[iel]))
+                return false;
+        }
+        if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) > 1.479) {
+            if (Electron_mvaFall17V1noIso()[iel] <=
+                electronMvacut(-0.81, -0.733, 0.176, Electron_pt()[iel]))
+                return false;
+        }
+        return true;
+        break;
+    case (3):
+        if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) < 0.8) {
+            if (Electron_mvaFall17V1noIso()[iel] <=
+                electronMvacut(-0.93, -0.887, -0.135, Electron_pt()[iel]))
+                return false;
+        }
+        if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) >= 0.8 &&
+            fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) <= 1.479) {
+            if (Electron_mvaFall17V1noIso()[iel] <=
+                electronMvacut(-0.93, -0.89, -0.417, Electron_pt()[iel]))
+                return false;
+        }
+        if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) > 1.479) {
+            if (Electron_mvaFall17V1noIso()[iel] <=
+                electronMvacut(-0.942, -0.91, -0.470, Electron_pt()[iel]))
+                return false;
+        }
+        return true;
+        break;
     }
     cout << "wrong !!!!!!!should not see this message!!!! from ElectronSelection.C" << endl;
     return 0;
 }
-bool isTriggerSafenoIso_v3(int iel)
-{
-    if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) <= 1.479)
-    {
-        if (Electron_sieie()[iel] >= 0.011)
-        {
-            return false;
-        }
-        if (Electron_hoe()[iel] >= 0.08)
-        {
-            return false;
-        }
-        if (fabs(Electron_eInvMinusPInv()[iel]) >= 0.01 )
-        {
-            return false;
-        }
-    }
-    else if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) > 1.479 &&
-             fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) < 2.5)
-    {
-        if (Electron_sieie()[iel] >= 0.031)
-        {
-            return false;
-        }
-        if (Electron_hoe()[iel] >= 0.08)
-        {
-            return false;
-        }
-        if (fabs(Electron_eInvMinusPInv()[iel]) >= 0.01 )
-        {
-            return false;
-        }
+bool isTriggerSafenoIso_v3(int iel) {
+    if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) <= 1.479) {
+        if (Electron_sieie()[iel] >= 0.011) return false;
+        if (Electron_hoe()[iel] >= 0.08) return false;
+        if (fabs(Electron_eInvMinusPInv()[iel]) >= 0.01) return false;
+    } else if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) > 1.479 &&
+               fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) < 2.5) {
+        if (Electron_sieie()[iel] >= 0.031) return false;
+        if (Electron_hoe()[iel] >= 0.08) return false;
+        if (fabs(Electron_eInvMinusPInv()[iel]) >= 0.01) return false;
     }
     return true;
 }
-bool passElectronIso(double cut_miniiso, double cut_ptratio, double cut_ptrel, int iel)
-{
+bool passElectronIso(double cut_miniiso, double cut_ptratio, double cut_ptrel, int iel) {
     double val_miniiso = Electron_miniPFRelIso_all()[iel];
     double val_ptratio = 1 / (Electron_jetRelIso()[iel] + 1);
     double val_ptrel = Electron_jetPtRelv2()[iel];
     return (val_miniiso < cut_miniiso && ((val_ptratio > cut_ptratio) || (val_ptrel > cut_ptrel)));
 }
-
-

--- a/NanoCORE/IsolationTools.cc
+++ b/NanoCORE/IsolationTools.cc
@@ -2,28 +2,18 @@
 
 using namespace tas;
 
-bool passMultiIso(int id, int idx, float cutMiniIso, float cutPtRatio, float cutPtRel)
-{
-    float miniiso = abs(id) == 11 ?  Electron_miniPFRelIso_all()[idx] : Muon_miniPFRelIso_all()[idx];
-    if (miniiso > cutMiniIso)
-    {
-        return false;
-    }
+bool passMultiIso(int id, int idx, float cutMiniIso, float cutPtRatio, float cutPtRel) {
+    float miniiso = abs(id) == 11 ? Electron_miniPFRelIso_all()[idx] : Muon_miniPFRelIso_all()[idx];
+    if (miniiso > cutMiniIso) return false;
     // short circuit if we only are requiring miniiso (e.g., veto)
-    if (cutPtRatio < 0 && cutPtRel < 0)
-    {
-        return true;
-    }
+    if (cutPtRatio < 0 && cutPtRel < 0) return true;
     int closestJetIdx = abs(id) == 11 ? Electron_jetIdx()[idx] : Muon_jetIdx()[idx];
     float ptratio = 1.;
     float ptrel = 0.;
-    if (closestJetIdx < 0)
-    {
+    if (closestJetIdx < 0) {
         ptratio = 1.;
         ptrel = 0.;
-    }
-    else
-    {
+    } else {
         // NOTE missing JEC L2L3 (or L1) to correctly compute the closest jet p4
         LorentzVector closestJet = Jet_p4()[closestJetIdx];
         LorentzVector lepton = abs(id) == 11 ? Electron_p4()[idx] : Muon_p4()[idx];
@@ -33,12 +23,8 @@ bool passMultiIso(int id, int idx, float cutMiniIso, float cutPtRatio, float cut
     return (ptratio > cutPtRatio) || (ptrel > cutPtRel);
 }
 
-float computePtRel(const LorentzVector& lepp4, const LorentzVector& jetp4)
-{
-    if (jetp4.pt() <= 0.)
-    {
-        return 0.;
-    }
+float computePtRel(const LorentzVector &lepp4, const LorentzVector &jetp4) {
+    if (jetp4.pt() <= 0.) return 0.;
     LorentzVector jp4 = jetp4;
     jp4 -= lepp4;
     float dot = lepp4.Vect().Dot(jp4.Vect());
@@ -47,28 +33,22 @@ float computePtRel(const LorentzVector& lepp4, const LorentzVector& jetp4)
     return ptrel;
 }
 
-float getPtRel(int id, int idx)
-{
+float getPtRel(int id, int idx) {
     // NOTE missing JEC L2L3 (or L1) to correctly compute the closest jet p4
     int closestJetIdx = abs(id) == 11 ? Electron_jetIdx()[idx] : Muon_jetIdx()[idx];
-    if (closestJetIdx >= 0)
-    {
+    if (closestJetIdx >= 0) {
         LorentzVector closestJet = Jet_p4()[closestJetIdx];
         LorentzVector lepton = abs(id) == 11 ? Electron_p4()[idx] : Muon_p4()[idx];
         return computePtRel(lepton, closestJet);
-    }
-    else
-    {
+    } else {
         return 0.;
     }
 }
 
-float getPtRatio(int id, int idx)
-{
+float getPtRatio(int id, int idx) {
     // NOTE missing JEC L2L3 (or L1) to correctly compute the closest jet p4
     int closestJetIdx = abs(id) == 11 ? Electron_jetIdx()[idx] : Muon_jetIdx()[idx];
-    if (closestJetIdx >= 0)
-    {
+    if (closestJetIdx >= 0) {
         float leppt = abs(id) == 11 ? Electron_pt()[idx] : Muon_pt()[idx];
         return leppt / Jet_pt()[closestJetIdx];
     }

--- a/NanoCORE/IsolationTools.h
+++ b/NanoCORE/IsolationTools.h
@@ -2,10 +2,9 @@
 #define ISOLATIONTOOLS_H
 #include "Nano.h"
 
-
 float getPtRel(int id, int idx);
 float getPtRatio(int id, int idx);
-float computePtRel(const LorentzVector& lepp4, const LorentzVector& jetp4);
+float computePtRel(const LorentzVector &lepp4, const LorentzVector &jetp4);
 bool passMultiIso(int id, int idx, float cutMiniIso, float cutPtRatio, float cutPtRel);
 
 #endif

--- a/NanoCORE/MuonSelections.cc
+++ b/NanoCORE/MuonSelections.cc
@@ -2,113 +2,48 @@
 #include "IsolationTools.h"
 
 using namespace tas;
-bool muonIDVBS(unsigned int imu, string id_name)
-{
+bool muonIDVBS(unsigned int imu, string id_name) {
     int id_level_t;
     if (id_name == "2017_tight")
-    {
         id_level_t = 1;
-    }
     else if (id_name == "2017_loose")
-    {
         id_level_t = 2;
-    }
-    else
-    {
+    else {
         cout << "wrong input id name " << endl;
         return 0;
     }
-    switch (id_level_t)
-    {
-        case (1):
-            if (Muon_pt()[imu] < 10)
-            {
-                return false;
-            }
-            if (fabs(Muon_eta()[imu]) > 2.4)
-            {
-                return false;
-            }
-            if (fabs(Muon_dxy()[imu]) > 0.05)
-            {
-                return false;
-            }
-            if (fabs(Muon_dz()[imu]) > 0.1)
-            {
-                return false;
-            }
-            if (!Muon_looseId()[imu])
-            {
-                return false;
-            }
-            if (Muon_sip3d()[imu] >= 4)
-            {
-                return false;
-            }
-            if (!Muon_looseId()[imu])
-            {
-                return false;
-            }
-            if (Muon_ptErr()[imu] / Muon_pt()[imu] >= 0.2)
-            {
-                return false;
-            }
-            if (!Muon_mediumId()[imu])
-            {
-                return false;
-            }
-            if (!passMuonIso(0.11, 0.74, 6.8, imu))
-            {
-                return false;
-            }
-            return true;
-            break;
-        case (2):
-            if (Muon_pt()[imu] < 10)
-            {
-                return false;
-            }
-            if (fabs(Muon_eta()[imu]) > 2.4)
-            {
-                return false;
-            }
-            if (fabs(Muon_dxy()[imu]) > 0.05)
-            {
-                return false;
-            }
-            if (fabs(Muon_dz()[imu]) > 0.1)
-            {
-                return false;
-            }
-            if (Muon_sip3d()[imu] >= 4)
-            {
-                return false;
-            }
-            if (!Muon_looseId()[imu])
-            {
-                return false;
-            }
-            if (Muon_ptErr()[imu] / Muon_pt()[imu] >= 0.2)
-            {
-                return false;
-            }
-            if (!Muon_mediumId()[imu])
-            {
-                return false;
-            }
-            if (Muon_miniPFRelIso_all()[imu] > 0.40)
-            {
-                return false;
-            }
-            return true;
-            break;
+    switch (id_level_t) {
+    case (1):
+        if (Muon_pt()[imu] < 10) return false;
+        if (fabs(Muon_eta()[imu]) > 2.4) return false;
+        if (fabs(Muon_dxy()[imu]) > 0.05) return false;
+        if (fabs(Muon_dz()[imu]) > 0.1) return false;
+        if (!Muon_looseId()[imu]) return false;
+        if (Muon_sip3d()[imu] >= 4) return false;
+        if (!Muon_looseId()[imu]) return false;
+        if (Muon_ptErr()[imu] / Muon_pt()[imu] >= 0.2) return false;
+        if (!Muon_mediumId()[imu]) return false;
+        if (!passMuonIso(0.11, 0.74, 6.8, imu)) return false;
+        return true;
+        break;
+    case (2):
+        if (Muon_pt()[imu] < 10) return false;
+        if (fabs(Muon_eta()[imu]) > 2.4) return false;
+        if (fabs(Muon_dxy()[imu]) > 0.05) return false;
+        if (fabs(Muon_dz()[imu]) > 0.1) return false;
+        if (Muon_sip3d()[imu] >= 4) return false;
+        if (!Muon_looseId()[imu]) return false;
+        if (Muon_ptErr()[imu] / Muon_pt()[imu] >= 0.2) return false;
+        if (!Muon_mediumId()[imu]) return false;
+        if (Muon_miniPFRelIso_all()[imu] > 0.40) return false;
+        return true;
+        break;
     }
     cout << "Error from MuonSelection: should not see this message!!!!!" << endl;
     return 0;
 }
 
-bool passMuonIso(double cut_miniiso, double cut_ptratio, double cut_ptrel, int imu)
-{
+bool passMuonIso(double cut_miniiso, double cut_ptratio, double cut_ptrel, int imu) {
     double val_miniiso = Muon_miniPFRelIso_all()[imu];
     double val_ptratio = 1 / (Muon_jetRelIso()[imu] + 1);
     double val_ptrel = Muon_jetPtRelv2()[imu];

--- a/NanoCORE/SSSelections.cc
+++ b/NanoCORE/SSSelections.cc
@@ -2,194 +2,113 @@
 
 using namespace tas;
 
-Leptons getLeptons()
-{
+Leptons getLeptons() {
     Leptons leptons;
     auto mupts = Muon_pt();
-    for (unsigned int imu = 0; imu < mupts.size(); imu++)
-    {
-        if (mupts[imu] < 5)
-        {
-            continue;
-        }
+    for (unsigned int imu = 0; imu < mupts.size(); imu++) {
+        if (mupts[imu] < 5) continue;
         leptons.push_back(Lepton(Muon_pdgId()[imu], imu));
     }
     auto epts = Electron_pt();
-    for (unsigned int iel = 0; iel < epts.size(); iel++)
-    {
-        if (epts[iel] < 7)
-        {
-            continue;
-        }
+    for (unsigned int iel = 0; iel < epts.size(); iel++) {
+        if (epts[iel] < 7) continue;
         leptons.push_back(Lepton(Electron_pdgId()[iel], iel));
     }
     return leptons;
 }
 
-std::tuple<int, int, float> getJetInfo(Leptons& leps, int variation)
-{
+std::tuple<int, int, float> getJetInfo(Leptons &leps, int variation) {
     int njets = 0;
     float ht = 0;
     int nbtags = 0;
     auto jetpts = Jet_pt();
     vector<float> discs = Jet_btagDeepB();
-    for (unsigned int ijet = 0; ijet < jetpts.size(); ijet += 1)
-    {
+    for (unsigned int ijet = 0; ijet < jetpts.size(); ijet += 1) {
         float pt = jetpts[ijet];
-        if (!(Jet_jetId()[ijet] & (1 << 1)))
-        {
-            continue;
-        }
+        if (!(Jet_jetId()[ijet] & (1 << 1))) continue;
         // Clean against up to 2 fakable electrons
-        if (Jet_electronIdx1()[ijet] >= 0)
-        {
+        if (Jet_electronIdx1()[ijet] >= 0) {
             bool skip = false;
-            for (auto& lep : leps)
-            {
-                if (lep.is_el() && (Jet_electronIdx1()[ijet] == (int)(lep.idx())) && lep.idlevel() >= IDfakable)
-                {
+            for (auto &lep : leps) {
+                if (lep.is_el() && (Jet_electronIdx1()[ijet] == (int)(lep.idx())) &&
+                    lep.idlevel() >= IDfakable) {
                     skip = true;
                     break;
                 }
-                if (skip)
-                {
-                    break;
-                }
-                if (Jet_electronIdx2()[ijet] >= 0)
-                {
-                    if (lep.is_el() && (Jet_electronIdx2()[ijet] == (int)(lep.idx())) && lep.idlevel() >= IDfakable)
-                    {
+                if (skip) break;
+                if (Jet_electronIdx2()[ijet] >= 0) {
+                    if (lep.is_el() && (Jet_electronIdx2()[ijet] == (int)(lep.idx())) &&
+                        lep.idlevel() >= IDfakable) {
                         skip = true;
                         break;
                     }
-                    if (skip)
-                    {
-                        break;
-                    }
+                    if (skip) break;
                 }
             }
-            if (skip)
-            {
-                continue;
-            }
+            if (skip) continue;
         }
         // Clean against up to 2 fakable muons
-        if (Jet_muonIdx1()[ijet] >= 0)
-        {
+        if (Jet_muonIdx1()[ijet] >= 0) {
             bool skip = false;
-            for (auto& lep : leps)
-            {
-                if (lep.is_mu() && (Jet_muonIdx1()[ijet] == (int)(lep.idx())) && lep.idlevel() >= IDfakable)
-                {
+            for (auto &lep : leps) {
+                if (lep.is_mu() && (Jet_muonIdx1()[ijet] == (int)(lep.idx())) &&
+                    lep.idlevel() >= IDfakable) {
                     skip = true;
                     break;
                 }
-                if (skip)
-                {
-                    break;
-                }
-                if (Jet_muonIdx2()[ijet] >= 0)
-                {
-                    if (lep.is_mu() && (Jet_muonIdx2()[ijet] == (int)(lep.idx())) && lep.idlevel() >= IDfakable)
-                    {
+                if (skip) { break; }
+                if (Jet_muonIdx2()[ijet] >= 0) {
+                    if (lep.is_mu() && (Jet_muonIdx2()[ijet] == (int)(lep.idx())) &&
+                        lep.idlevel() >= IDfakable) {
                         skip = true;
                         break;
                     }
-                    if (skip)
-                    {
-                        break;
-                    }
+                    if (skip) { break; }
                 }
             }
-            if (skip)
-            {
-                continue;
-            }
+            if (skip) continue;
         }
-        if (fabs(Jet_eta()[ijet]) > 2.4)
-        {
-            continue;
-        }
-        if (pt > 25. && discs[ijet] > 0.4941)
-        {
-            nbtags += 1;
-        }
-        if (pt < 40)
-        {
-            continue;
-        }
+        if (fabs(Jet_eta()[ijet]) > 2.4) continue;
+        if (pt > 25. && discs[ijet] > 0.4941) nbtags += 1;
+        if (pt < 40) continue;
         ht += pt;
         njets++;
     }
     return std::make_tuple(njets, nbtags, ht);
 }
 
-std::pair<int, int> makesResonance(Leptons& leps, Lepton lep1, Lepton lep2, float mass, float window)
-{
+std::pair<int, int> makesResonance(Leptons &leps, Lepton lep1, Lepton lep2, float mass,
+                                   float window) {
     // return {which lepton (1,2), and index of resonance partner}
-    for (auto& lep : leps)
-    {
-        if (lep.is_el())
-        {
-            if (!(lep1.is_el() || lep2.is_el()))
-            {
+    for (auto &lep : leps) {
+        if (lep.is_el()) {
+            if (!(lep1.is_el() || lep2.is_el())) continue;
+            if ((lep.idx() == lep1.idx() && lep1.is_el()) ||
+                (lep.idx() == lep2.idx() && lep2.is_el()))
                 continue;
-            }
-            if ((lep.idx() == lep1.idx() && lep1.is_el()) || (lep.idx() == lep2.idx() && lep2.is_el()))
-            {
-                continue;
-            }
-            if (fabs(lep.eta()) > 2.4)
-            {
-                continue;
-            }
-            if (lep.pt() < 7)
-            {
-                continue;
-            }
-            if (lep.idlevel() < IDveto)
-            {
-                continue;
-            }
-            if (lep1.is_el() && (lep1.id() * lep.id() < 0) && (fabs((lep1.p4() + lep.p4()).M() - mass) < window))
-            {
+            if (fabs(lep.eta()) > 2.4) continue;
+            if (lep.pt() < 7) continue;
+            if (lep.idlevel() < IDveto) continue;
+            if (lep1.is_el() && (lep1.id() * lep.id() < 0) &&
+                (fabs((lep1.p4() + lep.p4()).M() - mass) < window))
                 return {1, lep.idx()};
-            }
-            if (lep2.is_el() && (lep2.id() * lep.id() < 0) && (fabs((lep2.p4() + lep.p4()).M() - mass) < window))
-            {
+            if (lep2.is_el() && (lep2.id() * lep.id() < 0) &&
+                (fabs((lep2.p4() + lep.p4()).M() - mass) < window))
                 return {2, lep.idx()};
-            }
-        }
-        else
-        {
-            if (!(lep1.is_mu() || lep2.is_mu()))
-            {
+        } else {
+            if (!(lep1.is_mu() || lep2.is_mu())) continue;
+            if ((lep.idx() == lep1.idx() && lep1.is_mu()) ||
+                (lep.idx() == lep2.idx() && lep2.is_mu()))
                 continue;
-            }
-            if ((lep.idx() == lep1.idx() && lep1.is_mu()) || (lep.idx() == lep2.idx() && lep2.is_mu()))
-            {
-                continue;
-            }
-            if (fabs(lep.eta()) > 2.4)
-            {
-                continue;
-            }
-            if (lep.pt() < 5)
-            {
-                continue;
-            }
-            if (lep.idlevel() < IDveto)
-            {
-                continue;
-            }
-            if (lep1.is_mu() && (lep1.id() * lep.id() < 0) && (fabs((lep1.p4() + lep.p4()).M() - mass) < window))
-            {
+            if (fabs(lep.eta()) > 2.4) continue;
+            if (lep.pt() < 5) continue;
+            if (lep.idlevel() < IDveto) continue;
+            if (lep1.is_mu() && (lep1.id() * lep.id() < 0) &&
+                (fabs((lep1.p4() + lep.p4()).M() - mass) < window))
                 return {1, lep.idx()};
-            }
-            if (lep2.is_mu() && (lep2.id() * lep.id() < 0) && (fabs((lep2.p4() + lep.p4()).M() - mass) < window))
-            {
+            if (lep2.is_mu() && (lep2.id() * lep.id() < 0) &&
+                (fabs((lep2.p4() + lep.p4()).M() - mass) < window))
                 return {2, lep.idx()};
-            }
         }
     }
     // for (unsigned int iel = 0; iel < Electron_pt().size(); iel++) {
@@ -197,10 +116,12 @@ std::pair<int, int> makesResonance(Leptons& leps, Lepton lep1, Lepton lep2, floa
     //     if (fabs(Electron_eta()[iel]) > 2.4) continue;
     //     if (fabs(Electron_pt()[iel]) < 7) continue;
     //     if (!isVetoElectron(iel)) continue;
-    //     if (lep1.is_el() && (lep1.id() * Electron_pdgId()[iel] < 0) && (fabs((lep1.p4() + Electron_p4()[iel]).M()-mass) < window)) {
+    //     if (lep1.is_el() && (lep1.id() * Electron_pdgId()[iel] < 0) && (fabs((lep1.p4() +
+    //     Electron_p4()[iel]).M()-mass) < window)) {
     //         return {1,iel};
     //     }
-    //     if (lep2.is_el() && (lep2.id() * Electron_pdgId()[iel] < 0) && (fabs((lep2.p4() + Electron_p4()[iel]).M()-mass) < window)) {
+    //     if (lep2.is_el() && (lep2.id() * Electron_pdgId()[iel] < 0) && (fabs((lep2.p4() +
+    //     Electron_p4()[iel]).M()-mass) < window)) {
     //         return {2,iel};
     //     }
     // }
@@ -209,111 +130,74 @@ std::pair<int, int> makesResonance(Leptons& leps, Lepton lep1, Lepton lep2, floa
     //     if (fabs(Muon_eta()[imu]) > 2.4) continue;
     //     if (fabs(Muon_pt()[imu]) < 5) continue;
     //     if (!isVetoMuon(imu)) continue;
-    //     if (lep1.is_mu() && (lep1.id() * Muon_pdgId()[imu] < 0) && (fabs((lep1.p4() + Muon_p4()[imu]).M()-mass) < window)) {
+    //     if (lep1.is_mu() && (lep1.id() * Muon_pdgId()[imu] < 0) && (fabs((lep1.p4() +
+    //     Muon_p4()[imu]).M()-mass) < window)) {
     //         return {1,imu};
     //     }
-    //     if (lep2.is_mu() && (lep2.id() * Muon_pdgId()[imu] < 0) && (fabs((lep2.p4() + Muon_p4()[imu]).M()-mass) < window)) {
+    //     if (lep2.is_mu() && (lep2.id() * Muon_pdgId()[imu] < 0) && (fabs((lep2.p4() +
+    //     Muon_p4()[imu]).M()-mass) < window)) {
     //         return {2,imu};
     //     }
     // }
     return {-1, -1};
 }
 
-
-std::pair<int, Hyp> getBestHyp(Leptons& leptons)
-{
+std::pair<int, Hyp> getBestHyp(Leptons &leptons) {
     int hyp_class = -1;
     Hyp best_hyp;
-    if (leptons.size() < 2)
-        return {hyp_class, best_hyp};
+    if (leptons.size() < 2) return {hyp_class, best_hyp};
     vector<Hyp> hyp1s;
     vector<Hyp> hyp2s;
     vector<Hyp> hyp3s;
     vector<Hyp> hyp4s;
     vector<Hyp> hyp6s;
-    for (unsigned int i = 0; i < leptons.size(); i++)
-    {
-        for (unsigned int j = i + 1; j < leptons.size(); j++)
-        {
-            auto& lep1 = leptons[i];
-            auto& lep2 = leptons[j];
-            if (lep1.idlevel() < IDfakable || lep2.idlevel() < IDfakable)
-            {
-                continue;
-            }
+    for (unsigned int i = 0; i < leptons.size(); i++) {
+        for (unsigned int j = i + 1; j < leptons.size(); j++) {
+            auto &lep1 = leptons[i];
+            auto &lep2 = leptons[j];
+            if (lep1.idlevel() < IDfakable || lep2.idlevel() < IDfakable) continue;
             bool isss = lep1.charge() == lep2.charge();
             int ntight = (lep1.idlevel() == IDtight) + (lep2.idlevel() == IDtight);
             int nloose = (lep1.idlevel() == IDfakable) + (lep2.idlevel() == IDfakable);
-            if (lep1.is_el())
-            {
-                if (lep1.pt() < 15. || fabs(lep1.eta()) > 2.5)
-                {
-                    continue;
-                }
+            if (lep1.is_el()) {
+                if (lep1.pt() < 15. || fabs(lep1.eta()) > 2.5) continue;
+            } else {
+                if (lep1.pt() < 10. || fabs(lep1.eta()) > 2.4) continue;
             }
-            else
-            {
-                if (lep1.pt() < 10. || fabs(lep1.eta()) > 2.4)
-                {
-                    continue;
-                }
-            }
-            if (lep2.is_el())
-            {
-                if (lep2.pt() < 15. || fabs(lep2.eta()) > 2.5)
-                {
-                    continue;
-                }
-            }
-            else
-            {
-                if (lep2.pt() < 10. || fabs(lep2.eta()) > 2.4)
-                {
-                    continue;
-                }
+            if (lep2.is_el()) {
+                if (lep2.pt() < 15. || fabs(lep2.eta()) > 2.5) continue;
+            } else {
+                if (lep2.pt() < 10. || fabs(lep2.eta()) > 2.4) continue;
             }
             // Veto SS ee or any OSSF, with mll < 12
-            if ((isss && lep1.is_el() && lep2.is_el()) || (lep1.id() == -lep2.id()))
-            {
-                if ((lep1.p4() + lep2.p4()).M() < 12.)
-                {
-                    continue;
-                }
+            if ((isss && lep1.is_el() && lep2.is_el()) || (lep1.id() == -lep2.id())) {
+                if ((lep1.p4() + lep2.p4()).M() < 12.) continue;
             }
             auto z_result = makesResonance(leptons, lep1, lep2, 91., 15.);
             auto gammastar_result = makesResonance(leptons, lep1, lep2, 0., 12.);
             bool extraZ = z_result.first >= 0;
             bool extraGammaStar = gammastar_result.first >= 0;
-            if ((extraZ || extraGammaStar) && isss)
-            {
+            if ((extraZ || extraGammaStar) && isss) {
                 if (lep1.pt() > lep2.pt())
                     hyp6s.push_back({lep1, lep2});
                 else
                     hyp6s.push_back({lep2, lep1});
-            }
-            else if (ntight == 2 && isss)
-            {
+            } else if (ntight == 2 && isss) {
                 if (lep1.pt() > lep2.pt())
                     hyp3s.push_back({lep1, lep2});
                 else
                     hyp3s.push_back({lep2, lep1});
-            }
-            else if (ntight == 0 && nloose == 2 && isss)
-            {
+            } else if (ntight == 0 && nloose == 2 && isss) {
                 if (lep1.pt() > lep2.pt())
                     hyp1s.push_back({lep1, lep2});
                 else
                     hyp1s.push_back({lep2, lep1});
-            }
-            else if (ntight == 1 && nloose == 1 && isss)
-            {
+            } else if (ntight == 1 && nloose == 1 && isss) {
                 if (lep1.pt() > lep2.pt())
                     hyp2s.push_back({lep1, lep2});
                 else
                     hyp2s.push_back({lep2, lep1});
-            }
-            else if (ntight == 2 && !isss)
-            {
+            } else if (ntight == 2 && !isss) {
                 if (lep1.pt() > lep2.pt())
                     hyp4s.push_back({lep1, lep2});
                 else
@@ -323,399 +207,193 @@ std::pair<int, Hyp> getBestHyp(Leptons& leptons)
     }
     vector<Hyp> hyps;
     // Priority order - 3,6,2,1,4
-    if (hyp3s.size() > 0)
-    {
+    if (hyp3s.size() > 0) {
         hyps = hyp3s;
         hyp_class = 3;
-    }
-    else if (hyp6s.size() > 0)
-    {
+    } else if (hyp6s.size() > 0) {
         hyps = hyp6s;
         hyp_class = 6;
-    }
-    else if (hyp2s.size() > 0)
-    {
+    } else if (hyp2s.size() > 0) {
         hyps = hyp2s;
         hyp_class = 2;
-    }
-    else if (hyp1s.size() > 0)
-    {
+    } else if (hyp1s.size() > 0) {
         hyps = hyp1s;
         hyp_class = 1;
-    }
-    else if (hyp4s.size() > 0)
-    {
+    } else if (hyp4s.size() > 0) {
         hyps = hyp4s;
         hyp_class = 4;
     }
-    if ((hyp_class <= 0) || (hyps.size() < 1))
-        return {hyp_class, best_hyp};
-    if (hyps.size() == 1)
-    {
+    if ((hyp_class <= 0) || (hyps.size() < 1)) return {hyp_class, best_hyp};
+    if (hyps.size() == 1) {
         best_hyp = hyps[0];
-    }
-    else if (hyps.size() > 1)
-    {
+    } else if (hyps.size() > 1) {
         best_hyp = hyps[0];
-        for (unsigned int i = 1; i < hyps.size(); i++)
-        {
+        for (unsigned int i = 1; i < hyps.size(); i++) {
             Hyp hyp = hyps[i];
-            if (hyp.first.is_mu() + hyp.second.is_mu() > best_hyp.first.is_mu() + best_hyp.second.is_mu())
-            {
+            if (hyp.first.is_mu() + hyp.second.is_mu() >
+                best_hyp.first.is_mu() + best_hyp.second.is_mu())
                 best_hyp = hyp;
-            }
-            else if (hyp.first.is_mu() + hyp.second.is_mu() == best_hyp.first.is_mu() + best_hyp.second.is_mu())
-            {
+            else if (hyp.first.is_mu() + hyp.second.is_mu() ==
+                     best_hyp.first.is_mu() + best_hyp.second.is_mu()) {
                 if (hyp.first.pt() + hyp.second.pt() > best_hyp.first.pt() + best_hyp.second.pt())
-                {
                     best_hyp = hyp;
-                }
             }
         }
     }
     return {hyp_class, best_hyp};
 }
 
-
-
-bool isTriggerSafenoIso_v1(int iel)
-{
+bool isTriggerSafenoIso_v1(int iel) {
     float etaSC = Electron_eta()[iel] + Electron_deltaEtaSC()[iel];
-    if (fabs(etaSC) <= 1.479)
-    {
-        if (Electron_sieie()[iel] >= 0.011)
-        {
-            return false;
-        }
-        if (Electron_hoe()[iel] >= 0.08)
-        {
-            return false;
-        }
+    if (fabs(etaSC) <= 1.479) {
+        if (Electron_sieie()[iel] >= 0.011) return false;
+        if (Electron_hoe()[iel] >= 0.08) return false;
         // if (fabs(els_dEtaIn().at(iel)) >= 0.01) return false; // NOTE missing
         // if (fabs(els_dPhiIn().at(iel)) >= 0.04) return false; // NOTE missing
-        if (fabs(Electron_eInvMinusPInv()[iel]) >= 0.01)
-        {
-            return false;
-        }
-    }
-    else if ((fabs(etaSC) > 1.479) && (fabs(etaSC) < 2.5))
-    {
-        if (Electron_sieie()[iel] >= 0.031)
-        {
-            return false;
-        }
-        if (Electron_hoe()[iel] >= 0.08)
-        {
-            return false;
-        }
+        if (fabs(Electron_eInvMinusPInv()[iel]) >= 0.01) return false;
+    } else if ((fabs(etaSC) > 1.479) && (fabs(etaSC) < 2.5)) {
+        if (Electron_sieie()[iel] >= 0.031) return false;
+        if (Electron_hoe()[iel] >= 0.08) return false;
         // if (fabs(els_dEtaIn().at(iel)) >= 0.01) return false;
         // if (fabs(els_dPhiIn().at(iel)) >= 0.08) return false;
-        if (fabs(Electron_eInvMinusPInv()[iel]) >= 0.01)
-        {
-            return false;
-        }
+        if (fabs(Electron_eInvMinusPInv()[iel]) >= 0.01) return false;
     }
     return true;
 }
 
-bool isTriggerSafeIso_v1(int iel)
-{
-    if (!isTriggerSafenoIso_v1(iel))
-    {
-        return false;
-    }
-    if (Electron_dr03EcalRecHitSumEt()[iel] / Electron_pt()[iel] >= 0.45)
-    {
-        return false;
-    }
-    if (Electron_dr03HcalDepth1TowerSumEt()[iel] / Electron_pt()[iel] >= 0.25)
-    {
-        return false;
-    }
-    if (Electron_dr03TkSumPt()[iel] / Electron_pt()[iel] >= 0.2)
-    {
-        return false;
-    }
+bool isTriggerSafeIso_v1(int iel) {
+    if (!isTriggerSafenoIso_v1(iel)) return false;
+    if (Electron_dr03EcalRecHitSumEt()[iel] / Electron_pt()[iel] >= 0.45) return false;
+    if (Electron_dr03HcalDepth1TowerSumEt()[iel] / Electron_pt()[iel] >= 0.25) return false;
+    if (Electron_dr03TkSumPt()[iel] / Electron_pt()[iel] >= 0.2) return false;
     return true;
 }
 
-bool passesElectronMVA(int idlevel, int iel)
-{
+bool passesElectronMVA(int idlevel, int iel) {
     // C if pT<10, A if pT=10, B if pt>=25, lerp between A,B for pT in [10,25]
-    auto mvacut = [](float A, float B, float C, float pt_)
-    {
+    auto mvacut = [](float A, float B, float C, float pt_) {
         if (pt_ < 10)
-        {
             return C;
-        }
         else if (pt_ > 25)
-        {
             return B;
-        }
         else
-        {
             return A + (B - A) / 15.0f * (pt_ - 10.0f);
-        }
     };
     float mva = Electron_mvaFall17V1noIso()[iel];
     float pt = Electron_pt()[iel];
     float aeta = fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]);
-    if (idlevel == IDtight)
-    {
-        if (aeta < 0.8)
-        {
-            return mva > mvacut(0.2, 0.68, 0.2, pt);
-        }
-        if ((aeta >= 0.8 && aeta <= 1.479))
-        {
-            return mva > mvacut(0.1, 0.475, 0.1, pt);
-        }
-        if (aeta > 1.479)
-        {
-            return mva > mvacut(-0.1, 0.32, -0.1, pt);
-        }
-    }
-    else if (idlevel == IDfakable)
-    {
-        if (aeta < 0.8)
-        {
-            return mva > mvacut(-0.788, -0.64, 0.488, pt);
-        }
-        if ((aeta >= 0.8 && aeta <= 1.479))
-        {
-            return mva > mvacut(-0.85, -0.775, -0.045, pt);
-        }
-        if (aeta > 1.479)
-        {
-            return mva > mvacut(-0.81, -0.733, 0.176, pt);
-        }
-    }
-    else if (idlevel == IDveto)
-    {
-        if (aeta < 0.8)
-        {
-            return mva > mvacut(-0.788, -0.64, 0.488, pt);
-        }
-        if ((aeta >= 0.8 && aeta <= 1.479))
-        {
-            return mva > mvacut(-0.85, -0.775, -0.045, pt);
-        }
-        if (aeta > 1.479)
-        {
-            return mva > mvacut(-0.81, -0.733, 0.176, pt);
-        }
+    if (idlevel == IDtight) {
+        if (aeta < 0.8) return mva > mvacut(0.2, 0.68, 0.2, pt);
+        if ((aeta >= 0.8 && aeta <= 1.479)) return mva > mvacut(0.1, 0.475, 0.1, pt);
+        if (aeta > 1.479) return mva > mvacut(-0.1, 0.32, -0.1, pt);
+    } else if (idlevel == IDfakable) {
+        if (aeta < 0.8) return mva > mvacut(-0.788, -0.64, 0.488, pt);
+        if ((aeta >= 0.8 && aeta <= 1.479)) return mva > mvacut(-0.85, -0.775, -0.045, pt);
+        if (aeta > 1.479) return mva > mvacut(-0.81, -0.733, 0.176, pt);
+    } else if (idlevel == IDveto) {
+        if (aeta < 0.8) return mva > mvacut(-0.788, -0.64, 0.488, pt);
+        if ((aeta >= 0.8 && aeta <= 1.479)) return mva > mvacut(-0.85, -0.775, -0.045, pt);
+        if (aeta > 1.479) return mva > mvacut(-0.81, -0.733, 0.176, pt);
     }
     return false;
 }
 
-bool isVetoElectron(int iel)
-{
-    if (Electron_pt()[iel] < 7)
-    {
-        return false;
-    }
-    if (Electron_miniPFRelIso_all()[iel] > 0.4)
-    {
-        return false;
-    }
-    if (Electron_convVeto()[iel] == 0)
-    {
-        return false;
-    }
-    if (Electron_lostHits()[iel] > 1)
-    {
-        return false;
-    }
-    if (fabs(Electron_dxy()[iel]) > 0.05)
-    {
-        return false;
-    }
-    if (fabs(Electron_dz()[iel]) >= 0.1)
-    {
-        return false;
-    }
-    if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) > 2.5)
-    {
-        return false;
-    }
-    if (!passesElectronMVA(IDveto, iel))
-    {
-        return false;
-    }
-    if (!isTriggerSafenoIso_v1(iel))
-    {
-        return false;
-    }
+bool isVetoElectron(int iel) {
+    if (Electron_pt()[iel] < 7) return false;
+    if (Electron_miniPFRelIso_all()[iel] > 0.4) return false;
+    if (Electron_convVeto()[iel] == 0) return false;
+    if (Electron_lostHits()[iel] > 1) return false;
+    if (fabs(Electron_dxy()[iel]) > 0.05) return false;
+    if (fabs(Electron_dz()[iel]) >= 0.1) return false;
+    if (fabs(Electron_eta()[iel] + Electron_deltaEtaSC()[iel]) > 2.5) return false;
+    if (!passesElectronMVA(IDveto, iel)) return false;
+    if (!isTriggerSafenoIso_v1(iel)) return false;
     return true;
 }
 
-bool isFakableElectron(int iel)
-{
-    if (!isVetoElectron(iel))
-    {
-        return false;
-    }
-    if (Electron_pt()[iel] < 10)
-    {
-        return false;
-    }
-    if (fabs(Electron_sip3d()[iel]) >= 4)
-    {
-        return false;
-    }
-    if (Electron_tightCharge()[iel] < 2)
-    {
-        return false;
-    }
-    if (!passesElectronMVA(IDfakable, iel))
-    {
-        return false;
-    }
+bool isFakableElectron(int iel) {
+    if (!isVetoElectron(iel)) return false;
+    if (Electron_pt()[iel] < 10) return false;
+    if (fabs(Electron_sip3d()[iel]) >= 4) return false;
+    if (Electron_tightCharge()[iel] < 2) return false;
+    if (!passesElectronMVA(IDfakable, iel)) return false;
     return true;
 }
 
-bool isGoodElectron(int iel)
-{
-    if (!isFakableElectron(iel))
-    {
-        return false;
-    }
-    if (!passesElectronMVA(IDtight, iel))
-    {
-        return false;
-    }
-    if (!passMultiIso(11, iel, 0.09, 0.85, 9.2))
-    {
-        return false;
-    }
+bool isGoodElectron(int iel) {
+    if (!isFakableElectron(iel)) return false;
+    if (!passesElectronMVA(IDtight, iel)) return false;
+    if (!passMultiIso(11, iel, 0.09, 0.85, 9.2)) return false;
     return true;
 }
 
-bool isVetoMuon(int imu)
-{
-    if (Muon_pt()[imu] < 5)
-    {
-        return false;
-    }
-    if (Muon_miniPFRelIso_all()[imu] > 0.4)
-    {
-        return false;
-    }
-    if (fabs(Muon_dxy()[imu]) > 0.05)
-    {
-        return false;
-    }
-    if (fabs(Muon_dz()[imu]) > 0.1)
-    {
-        return false;
-    }
-    if (fabs(Muon_eta()[imu]) > 2.4)
-    {
-        return false;
-    }
+bool isVetoMuon(int imu) {
+    if (Muon_pt()[imu] < 5) return false;
+    if (Muon_miniPFRelIso_all()[imu] > 0.4) return false;
+    if (fabs(Muon_dxy()[imu]) > 0.05) return false;
+    if (fabs(Muon_dz()[imu]) > 0.1) return false;
+    if (fabs(Muon_eta()[imu]) > 2.4) return false;
     // LooseMuonPOG -- only LoosePOG muons can even get stored in nanoaod
     return true;
 }
 
-
-bool isFakableMuon(int imu)
-{
-    if (!isVetoMuon(imu))
-    {
-        return false;
-    }
-    if (Muon_pt()[imu] < 10)
-    {
-        return false;
-    }
-    if (fabs(Muon_sip3d()[imu]) >= 4)
-    {
-        return false;
-    }
-    if (!Muon_tightCharge()[imu])
-    {
-        return false;    // pterr/pt<0.2
-    }
-    if (!Muon_mediumId()[imu])
-    {
-        return false;
-    }
+bool isFakableMuon(int imu) {
+    if (!isVetoMuon(imu)) return false;
+    if (Muon_pt()[imu] < 10) return false;
+    if (fabs(Muon_sip3d()[imu]) >= 4) return false;
+    if (!Muon_tightCharge()[imu]) return false; // pterr/pt<0.2
+    if (!Muon_mediumId()[imu]) return false;
     return true;
 }
 
-bool isGoodMuon(int imu)
-{
-    if (!isFakableMuon(imu))
-    {
-        return false;
-    }
-    if (!passMultiIso(13, imu, 0.12, 0.80, 7.5))
-    {
-        return false;
-    }
+bool isGoodMuon(int imu) {
+    if (!isFakableMuon(imu)) return false;
+    if (!passMultiIso(13, imu, 0.12, 0.80, 7.5)) return false;
     return true;
 }
 
-
-void dumpLeptonProperties(Lepton lep)
-{
+void dumpLeptonProperties(Lepton lep) {
     std::cout << lep << std::endl;
     int i = lep.idx();
-    if (lep.is_el())
-    {
+    if (lep.is_el()) {
         std::cout << "  -- etaSC: " << Electron_eta()[i] + Electron_deltaEtaSC()[i] << std::endl;
         std::cout << "  -- mva: " << Electron_mvaFall17V1noIso()[i] << std::endl;
         std::cout << "  -- lostHits: " << Electron_lostHits()[i] << std::endl;
         std::cout << "  -- miniRelIso: " << Electron_miniPFRelIso_all()[i] << std::endl;
         std::cout << "  -- ptRatio: " << getPtRatio(11, i) << std::endl;
         std::cout << "  -- ptRel: " << getPtRel(11, i) << std::endl;
-    }
-    else
-    {
+    } else {
         std::cout << "  -- miniRelIso: " << Muon_miniPFRelIso_all()[i] << std::endl;
         std::cout << "  -- ptRatio: " << getPtRatio(13, i) << std::endl;
         std::cout << "  -- ptRel: " << getPtRel(13, i) << std::endl;
     }
 }
 
-bool isLeptonLevel(IDLevel idlevel, int id, int idx)
-{
-    switch (idlevel)
-    {
-        case (IDveto):
-            return (abs(id) == 11 ? isVetoElectron(idx) : isVetoMuon(idx));
-        case (IDfakable):
-            return (abs(id) == 11 ? isFakableElectron(idx) : isFakableMuon(idx));
-        case (IDtight):
-            return (abs(id) == 11 ? isGoodElectron(idx) : isGoodMuon(idx));
-        default:
-            throw std::runtime_error("Invalid idlevel!");
+bool isLeptonLevel(IDLevel idlevel, int id, int idx) {
+    switch (idlevel) {
+    case (IDveto):
+        return (abs(id) == 11 ? isVetoElectron(idx) : isVetoMuon(idx));
+    case (IDfakable):
+        return (abs(id) == 11 ? isFakableElectron(idx) : isFakableMuon(idx));
+    case (IDtight):
+        return (abs(id) == 11 ? isGoodElectron(idx) : isGoodMuon(idx));
+    default:
+        throw std::runtime_error("Invalid idlevel!");
     }
     return false;
 }
 
-IDLevel whichLeptonLevel(int id, int idx)
-{
-    if (isLeptonLevel(IDveto, id, idx))
-    {
-        if (isLeptonLevel(IDfakable, id, idx))
-        {
+IDLevel whichLeptonLevel(int id, int idx) {
+    if (isLeptonLevel(IDveto, id, idx)) {
+        if (isLeptonLevel(IDfakable, id, idx)) {
             if (isLeptonLevel(IDtight, id, idx))
-            {
                 return IDtight;
-            }
             else
-            {
                 return IDfakable;
-            }
-        }
-        else
-        {
+        } else {
             return IDveto;
         }
-    }
-    else
-    {
+    } else {
         return IDdefault;
     }
 }

--- a/NanoCORE/SSSelections.cc
+++ b/NanoCORE/SSSelections.cc
@@ -30,15 +30,13 @@ std::tuple<int, int, float> getJetInfo(Leptons &leps, int variation) {
         if (Jet_electronIdx1()[ijet] >= 0) {
             bool skip = false;
             for (auto &lep : leps) {
-                if (lep.is_el() && (Jet_electronIdx1()[ijet] == (int)(lep.idx())) &&
-                    lep.idlevel() >= IDfakable) {
+                if (lep.is_el() && (Jet_electronIdx1()[ijet] == (int)(lep.idx())) && lep.idlevel() >= IDfakable) {
                     skip = true;
                     break;
                 }
                 if (skip) break;
                 if (Jet_electronIdx2()[ijet] >= 0) {
-                    if (lep.is_el() && (Jet_electronIdx2()[ijet] == (int)(lep.idx())) &&
-                        lep.idlevel() >= IDfakable) {
+                    if (lep.is_el() && (Jet_electronIdx2()[ijet] == (int)(lep.idx())) && lep.idlevel() >= IDfakable) {
                         skip = true;
                         break;
                     }
@@ -51,15 +49,13 @@ std::tuple<int, int, float> getJetInfo(Leptons &leps, int variation) {
         if (Jet_muonIdx1()[ijet] >= 0) {
             bool skip = false;
             for (auto &lep : leps) {
-                if (lep.is_mu() && (Jet_muonIdx1()[ijet] == (int)(lep.idx())) &&
-                    lep.idlevel() >= IDfakable) {
+                if (lep.is_mu() && (Jet_muonIdx1()[ijet] == (int)(lep.idx())) && lep.idlevel() >= IDfakable) {
                     skip = true;
                     break;
                 }
                 if (skip) { break; }
                 if (Jet_muonIdx2()[ijet] >= 0) {
-                    if (lep.is_mu() && (Jet_muonIdx2()[ijet] == (int)(lep.idx())) &&
-                        lep.idlevel() >= IDfakable) {
+                    if (lep.is_mu() && (Jet_muonIdx2()[ijet] == (int)(lep.idx())) && lep.idlevel() >= IDfakable) {
                         skip = true;
                         break;
                     }
@@ -77,37 +73,28 @@ std::tuple<int, int, float> getJetInfo(Leptons &leps, int variation) {
     return std::make_tuple(njets, nbtags, ht);
 }
 
-std::pair<int, int> makesResonance(Leptons &leps, Lepton lep1, Lepton lep2, float mass,
-                                   float window) {
+std::pair<int, int> makesResonance(Leptons &leps, Lepton lep1, Lepton lep2, float mass, float window) {
     // return {which lepton (1,2), and index of resonance partner}
     for (auto &lep : leps) {
         if (lep.is_el()) {
             if (!(lep1.is_el() || lep2.is_el())) continue;
-            if ((lep.idx() == lep1.idx() && lep1.is_el()) ||
-                (lep.idx() == lep2.idx() && lep2.is_el()))
-                continue;
+            if ((lep.idx() == lep1.idx() && lep1.is_el()) || (lep.idx() == lep2.idx() && lep2.is_el())) continue;
             if (fabs(lep.eta()) > 2.4) continue;
             if (lep.pt() < 7) continue;
             if (lep.idlevel() < IDveto) continue;
-            if (lep1.is_el() && (lep1.id() * lep.id() < 0) &&
-                (fabs((lep1.p4() + lep.p4()).M() - mass) < window))
+            if (lep1.is_el() && (lep1.id() * lep.id() < 0) && (fabs((lep1.p4() + lep.p4()).M() - mass) < window))
                 return {1, lep.idx()};
-            if (lep2.is_el() && (lep2.id() * lep.id() < 0) &&
-                (fabs((lep2.p4() + lep.p4()).M() - mass) < window))
+            if (lep2.is_el() && (lep2.id() * lep.id() < 0) && (fabs((lep2.p4() + lep.p4()).M() - mass) < window))
                 return {2, lep.idx()};
         } else {
             if (!(lep1.is_mu() || lep2.is_mu())) continue;
-            if ((lep.idx() == lep1.idx() && lep1.is_mu()) ||
-                (lep.idx() == lep2.idx() && lep2.is_mu()))
-                continue;
+            if ((lep.idx() == lep1.idx() && lep1.is_mu()) || (lep.idx() == lep2.idx() && lep2.is_mu())) continue;
             if (fabs(lep.eta()) > 2.4) continue;
             if (lep.pt() < 5) continue;
             if (lep.idlevel() < IDveto) continue;
-            if (lep1.is_mu() && (lep1.id() * lep.id() < 0) &&
-                (fabs((lep1.p4() + lep.p4()).M() - mass) < window))
+            if (lep1.is_mu() && (lep1.id() * lep.id() < 0) && (fabs((lep1.p4() + lep.p4()).M() - mass) < window))
                 return {1, lep.idx()};
-            if (lep2.is_mu() && (lep2.id() * lep.id() < 0) &&
-                (fabs((lep2.p4() + lep.p4()).M() - mass) < window))
+            if (lep2.is_mu() && (lep2.id() * lep.id() < 0) && (fabs((lep2.p4() + lep.p4()).M() - mass) < window))
                 return {2, lep.idx()};
         }
     }
@@ -230,13 +217,10 @@ std::pair<int, Hyp> getBestHyp(Leptons &leptons) {
         best_hyp = hyps[0];
         for (unsigned int i = 1; i < hyps.size(); i++) {
             Hyp hyp = hyps[i];
-            if (hyp.first.is_mu() + hyp.second.is_mu() >
-                best_hyp.first.is_mu() + best_hyp.second.is_mu())
+            if (hyp.first.is_mu() + hyp.second.is_mu() > best_hyp.first.is_mu() + best_hyp.second.is_mu())
                 best_hyp = hyp;
-            else if (hyp.first.is_mu() + hyp.second.is_mu() ==
-                     best_hyp.first.is_mu() + best_hyp.second.is_mu()) {
-                if (hyp.first.pt() + hyp.second.pt() > best_hyp.first.pt() + best_hyp.second.pt())
-                    best_hyp = hyp;
+            else if (hyp.first.is_mu() + hyp.second.is_mu() == best_hyp.first.is_mu() + best_hyp.second.is_mu()) {
+                if (hyp.first.pt() + hyp.second.pt() > best_hyp.first.pt() + best_hyp.second.pt()) best_hyp = hyp;
             }
         }
     }

--- a/NanoCORE/SSSelections.h
+++ b/NanoCORE/SSSelections.h
@@ -48,12 +48,11 @@ typedef std::vector<Lepton> Leptons;
 
 std::ostream &operator<<(std::ostream &os, Lepton &lep) {
     std::string lepstr = (abs(lep.id()) == 11) ? "Electron" : "Muon";
-    return os << "<" << lepstr << " id=" << std::showpos << setw(3) << lep.id() << std::noshowpos
-              << ", idx=" << setw(2) << lep.idx() << ", level=" << lep.idlevel() << ", (pT,eta)="
+    return os << "<" << lepstr << " id=" << std::showpos << setw(3) << lep.id() << std::noshowpos << ", idx=" << setw(2)
+              << lep.idx() << ", level=" << lep.idlevel() << ", (pT,eta)="
               << "(" << lep.pt() << "," << lep.eta() << ")>";
 }
-template <typename T1, typename T2>
-std::ostream &operator<<(std::ostream &os, std::pair<T1, T2> &p) {
+template <typename T1, typename T2> std::ostream &operator<<(std::ostream &os, std::pair<T1, T2> &p) {
     return os << "(" << p.first << ", " << p.second << ")";
 }
 

--- a/NanoCORE/SSSelections.h
+++ b/NanoCORE/SSSelections.h
@@ -1,10 +1,9 @@
 #ifndef SSSELECTIONS_H
 #define SSSELECTIONS_H
-#include "Nano.h"
 #include "IsolationTools.h"
+#include "Nano.h"
 
-enum IDLevel
-{
+enum IDLevel {
     IDdefault = -1,
     IDveto = 0, // for Z-veto
     IDfakablenoiso = 1,
@@ -15,30 +14,28 @@ enum IDLevel
 
 IDLevel whichLeptonLevel(int id, int idx);
 
-struct Lepton
-{
-    Lepton(int id = 0, unsigned int idx = 0): id_(id), idx_(idx)
-    {
-        if (id != 0)
-        {
+struct Lepton {
+    Lepton(int id = 0, unsigned int idx = 0) : id_(id), idx_(idx) {
+        if (id != 0) {
             pt_ = (abs(id_) == 11 ? nt.Electron_pt()[idx_] : nt.Muon_pt()[idx_]);
             eta_ = (abs(id_) == 11 ? nt.Electron_eta()[idx_] : nt.Muon_eta()[idx_]);
             p4_ = (abs(id_) == 11 ? nt.Electron_p4()[idx_] : nt.Muon_p4()[idx_]);
             idlevel_ = whichLeptonLevel(id_, idx_);
         }
     }
-    void set_idlevel(int idlevel) {idlevel_ = idlevel;}
-    int id() {return id_;}
-    int absid() {return abs(id_);}
-    int is_el() {return abs(id_) == 11;}
-    int is_mu() {return abs(id_) == 13;}
-    int charge() {return -1 * id_ / abs(id_);}
-    unsigned int idx() {return idx_;}
-    int idlevel() {return idlevel_;}
-    LorentzVector p4() {return p4_;}
-    float pt() {return pt_;}
-    float eta() {return eta_;}
-private:
+    void set_idlevel(int idlevel) { idlevel_ = idlevel; }
+    int id() { return id_; }
+    int absid() { return abs(id_); }
+    int is_el() { return abs(id_) == 11; }
+    int is_mu() { return abs(id_) == 13; }
+    int charge() { return -1 * id_ / abs(id_); }
+    unsigned int idx() { return idx_; }
+    int idlevel() { return idlevel_; }
+    LorentzVector p4() { return p4_; }
+    float pt() { return pt_; }
+    float eta() { return eta_; }
+
+  private:
     int id_;
     float pt_ = 0.;
     float eta_ = 0.;
@@ -49,22 +46,20 @@ private:
 typedef std::pair<Lepton, Lepton> Hyp;
 typedef std::vector<Lepton> Leptons;
 
-std::ostream& operator << (std::ostream& os, Lepton& lep)
-{
+std::ostream &operator<<(std::ostream &os, Lepton &lep) {
     std::string lepstr = (abs(lep.id()) == 11) ? "Electron" : "Muon";
     return os << "<" << lepstr << " id=" << std::showpos << setw(3) << lep.id() << std::noshowpos
-           << ", idx=" << setw(2) << lep.idx() << ", level=" << lep.idlevel()
-           << ", (pT,eta)=" << "(" << lep.pt() << "," << lep.eta() << ")>";
+              << ", idx=" << setw(2) << lep.idx() << ", level=" << lep.idlevel() << ", (pT,eta)="
+              << "(" << lep.pt() << "," << lep.eta() << ")>";
 }
 template <typename T1, typename T2>
-std::ostream& operator << (std::ostream& os, std::pair<T1, T2>& p)
-{
+std::ostream &operator<<(std::ostream &os, std::pair<T1, T2> &p) {
     return os << "(" << p.first << ", " << p.second << ")";
 }
 
 vector<Lepton> getLeptons();
-std::tuple<int, int, float> getJetInfo(vector<Lepton>& leps, int variation = 0);
-std::pair<int, Hyp> getBestHyp(vector<Lepton>& leptons);
+std::tuple<int, int, float> getJetInfo(vector<Lepton> &leps, int variation = 0);
+std::pair<int, Hyp> getBestHyp(vector<Lepton> &leptons);
 bool isTriggerSafenoIso_v1(int iel);
 bool isTriggerSafeIso_v1(int iel);
 bool passesElectronMVA(int idlevel, int iel);

--- a/README.md
+++ b/README.md
@@ -1,18 +1,3 @@
-## Style
-
-We use `clang-format` based on LLVM style to format our code. To format the `ElectronSelections.cc` file in-place, do
-```bash
-clang-format -style="{BasedOnStyle: llvm, IndentWidth: 4, ColumnLimit: 120, AllowShortIfStatementsOnASingleLine: true, AllowShortBlocksOnASingleLine: true}" -i ElectronSelections.cc
-```
-
-Add this to the ```~/.vimrc``` and use ```vim``` to code. (Assumes you are working on UAF)
-
-    autocmd BufNewFile,BufRead *.cc,*.h,*.C,*.cxx set formatprg=clang-format\ -style=\"{BasedOnStyle:\ llvm,\ IndentWidth:\ 4,\ ColumnLimit:\ 100,\ AllowShortIfStatementsOnASingleLine:\ true,\ AllowShortBlocksOnASingleLine:\ true}\"
-
-To format press ```ggvGgq``` to format your code.
-
-## This is a WIP of course
-
 ### Environment & setup
 ```bash
 cd /cvmfs/cms.cern.ch/slc6_amd64_gcc700/cms/cmssw/CMSSW_10_2_9/ ; cmsenv ; cd -
@@ -26,3 +11,18 @@ make -j8 # takes about 20 seconds
 pip install uproot --user
 pip3 install uproot --user
 ```
+
+### Style
+
+We use `clang-format` based on LLVM style to format our code. To format the `ElectronSelections.cc` file in-place, do
+```bash
+clang-format -style="{BasedOnStyle: llvm, IndentWidth: 4, ColumnLimit: 120, AllowShortIfStatementsOnASingleLine: true, AllowShortBlocksOnASingleLine: true}" -i ElectronSelections.cc
+```
+
+Add this to the ```~/.vimrc``` and use ```vim``` to code. (Assumes you are working on UAF)
+```
+autocmd BufNewFile,BufRead *.cc,*.h,*.C,*.cxx set formatprg=clang-format\ -style=\"{BasedOnStyle:\ llvm,\ IndentWidth:\ 4,\ ColumnLimit:\ 100,\ AllowShortIfStatementsOnASingleLine:\ true,\ AllowShortBlocksOnASingleLine:\ true}\"
+```
+
+To format your code, press ```ggvGgq```.
+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 We use `clang-format` based on LLVM style to format our code. To format the `ElectronSelections.cc` file in-place, do
 ```bash
-clang-format -style="{BasedOnStyle: llvm, IndentWidth: 4, ColumnLimit: 100, AllowShortIfStatementsOnASingleLine: true, AllowShortBlocksOnASingleLine: true}" -i ElectronSelections.cc
+clang-format -style="{BasedOnStyle: llvm, IndentWidth: 4, ColumnLimit: 120, AllowShortIfStatementsOnASingleLine: true, AllowShortBlocksOnASingleLine: true}" -i ElectronSelections.cc
 ```
 
 Add this to the ```~/.vimrc``` and use ```vim``` to code. (Assumes you are working on UAF)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 ## Style
 
-We use artistic style to format our code
+We use `clang-format` based on LLVM style to format our code. To format the `ElectronSelections.cc` file in-place, do
+```bash
+clang-format -style="{BasedOnStyle: llvm, IndentWidth: 4, ColumnLimit: 100, AllowShortIfStatementsOnASingleLine: true, AllowShortBlocksOnASingleLine: true}" -i ElectronSelections.cc
+```
 
 Add this to the ```~/.vimrc``` and use ```vim``` to code. (Assumes you are working on UAF)
 
-    autocmd BufNewFile,BufRead *.cxx set formatprg=/home/users/phchang/software/bin/astyle\ -U\ --delete-empty-lines\ --pad-oper\ --keep-one-line-blocks\ --pad-header\ --style=allman\ --keep-one-line-blocks\ --indent-switches\ --break-one-line-headers\ --add-braces\ --pad-comma
-    autocmd BufNewFile,BufRead *.cc set formatprg=/home/users/phchang/software/bin/astyle\ -U\ --delete-empty-lines\ --pad-oper\ --keep-one-line-blocks\ --pad-header\ --style=allman\ --keep-one-line-blocks\ --indent-switches\ --break-one-line-headers\ --add-braces\ --pad-comma
-    autocmd BufNewFile,BufRead *.C set formatprg=/home/users/phchang/software/bin/astyle\ -U\ --delete-empty-lines\ --pad-oper\ --keep-one-line-blocks\ --pad-header\ --style=allman\ --keep-one-line-blocks\ --indent-switches\ --break-one-line-headers\ --add-braces\ --pad-comma
-    autocmd BufNewFile,BufRead *.h set formatprg=/home/users/phchang/software/bin/astyle\ -U\ --delete-empty-lines\ --pad-oper\ --keep-one-line-blocks\ --pad-header\ --style=allman\ --keep-one-line-blocks\ --indent-switches\ --break-one-line-headers\ --add-braces\ --pad-comma
+    autocmd BufNewFile,BufRead *.cc,*.h,*.C,*.cxx set formatprg=clang-format\ -style=\"{BasedOnStyle:\ llvm,\ IndentWidth:\ 4,\ ColumnLimit:\ 100,\ AllowShortIfStatementsOnASingleLine:\ true,\ AllowShortBlocksOnASingleLine:\ true}\"
 
-To format press ```ggvGgq``` to format your code in "artistic" way.
+To format press ```ggvGgq``` to format your code.
 
 ## This is a WIP of course
 


### PR DESCRIPTION
Switch from astyle to a more compact format via `clang-format` since it seems like more people use/conform to clang-format. The new format reduces the line count of `ElectronSelections.cc` by a factor of two, for example.

Also, this new format is pretty close to the (somewhat hodgepodge of) formats in `cmstas/CORE`. Maybe it makes comparing/diffing easier.