### PR TITLE
Added SS veto IDs

### DIFF
--- a/NanoCORE/Config.cc
+++ b/NanoCORE/Config.cc
@@ -166,7 +166,7 @@ void GlobalConfig::GetConfigs(int in_year) {
         jecEraB = "Autumn18_RunB_V8_DATA";
         jecEraC = "Autumn18_RunC_V8_DATA";
         jecEraD = "Autumn18_RunD_V8_DATA";
-        jecEraMC = "Autumn18_V8_MC";
+        jecEraMC = "Autumn18_V19_MC";
 
         // B-tag working points
         // https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation102X

--- a/NanoCORE/ElectronSelections.cc
+++ b/NanoCORE/ElectronSelections.cc
@@ -4,16 +4,25 @@
 using namespace tas;
 
 bool SS::electronID(int idx, SS::IDLevel id_level, int year) {
-    // Common checks
-    if (Electron_pt().at(idx) < 10.) { return false; }
+    // Common (across years and ID levels) checks
+    if (Electron_pt().at(idx) < 7.) { return false; }
     if (!isTriggerSafeNoIso(idx)) { return false; }
     if (fabs(Electron_eta().at(idx) + Electron_deltaEtaSC().at(idx)) > 2.5) { return false; }
     if (!Electron_convVeto().at(idx)) { return false; }
-    if (int(Electron_lostHits().at(idx)) > 0) { return false; }
-    if (Electron_tightCharge().at(idx) != 2) { return false; }
     if (fabs(Electron_dxy().at(idx)) >= 0.05) { return false; }
     if (fabs(Electron_dz().at(idx)) >= 0.1) { return false; }
-    if (fabs(Electron_sip3d().at(idx)) >= 4) { return false; }
+    if (int(Electron_lostHits().at(idx)) > 0) { return false; }
+    // Common (across years) checks
+    if (id_level < SS::IDtight) {
+        // Common (across years) veto and fakable(loose) checks
+        if (Electron_miniPFRelIso_all().at(idx) >= 0.4) { return false; }
+    } 
+    if (id_level > SS::IDveto) {
+        // Common (across years) fakable(loose) and tight checks
+        if (Electron_pt().at(idx) < 10.) { return false; }
+        if (Electron_tightCharge().at(idx) != 2) { return false; }
+        if (fabs(Electron_sip3d().at(idx)) >= 4) { return false; }
+    }
     // Year-specific checks
     switch (year) {
     case (2016):
@@ -33,7 +42,7 @@ bool SS::electronID(int idx, SS::IDLevel id_level, int year) {
 }
 
 bool SS::electron2016ID(int idx, SS::IDLevel id_level) {
-    // Common checks
+    // Common (for 2016) checks
     if (!passesElectronMVA(idx, SS::vetoNoIso2016, 2016)) { return false; }
     // ID-specific checks
     switch (id_level) {
@@ -42,7 +51,6 @@ bool SS::electron2016ID(int idx, SS::IDLevel id_level) {
         break;
     case (SS::IDfakable):
         if (!passesElectronMVA(idx, SS::fakableNoIsoLooseMVA2016, 2016)) { return false; }
-        if (Electron_miniPFRelIso_all().at(idx) >= 0.4) { return false; }
         return true;
         break;
     case (SS::IDtight):
@@ -59,7 +67,7 @@ bool SS::electron2016ID(int idx, SS::IDLevel id_level) {
 }
 
 bool SS::electron2017ID(int idx, SS::IDLevel id_level) {
-    // Common checks
+    // Common (for 2017) checks
     if (!passesElectronMVA(idx, SS::vetoNoIso2017, 2017)) { return false; }
     // ID-specific checks
     switch (id_level) {
@@ -68,7 +76,6 @@ bool SS::electron2017ID(int idx, SS::IDLevel id_level) {
         break;
     case (SS::IDfakable):
         if (!passesElectronMVA(idx, SS::fakableNoIsoLooseMVA2017, 2017)) { return false; }
-        if (Electron_miniPFRelIso_all().at(idx) >= 0.4) { return false; }
         return true;
         break;
     case (SS::IDtight):
@@ -85,7 +92,7 @@ bool SS::electron2017ID(int idx, SS::IDLevel id_level) {
 }
 
 bool SS::electron2018ID(int idx, SS::IDLevel id_level) {
-    // Common checks
+    // Common (for 2018) checks
     if (!passesElectronMVA(idx, SS::vetoNoIso2018, 2018)) { return false; }
     // ID-specific checks
     switch (id_level) {
@@ -94,7 +101,6 @@ bool SS::electron2018ID(int idx, SS::IDLevel id_level) {
         break;
     case (SS::IDfakable):
         if (!passesElectronMVA(idx, SS::fakableNoIsoLooseMVA2018, 2018)) { return false; }
-        if (Electron_miniPFRelIso_all().at(idx) >= 0.4) { return false; }
         return true;
         break;
     case (SS::IDtight):

--- a/NanoCORE/ElectronSelections.cc
+++ b/NanoCORE/ElectronSelections.cc
@@ -11,7 +11,7 @@ bool SS::electronID(int idx, SS::IDLevel id_level, int year) {
     if (!Electron_convVeto().at(idx)) { return false; }
     if (fabs(Electron_dxy().at(idx)) >= 0.05) { return false; }
     if (fabs(Electron_dz().at(idx)) >= 0.1) { return false; }
-    if (int(Electron_lostHits().at(idx)) > 0) { return false; }
+    if (int(Electron_lostHits().at(idx)) > 1) { return false; }
     // Common (across years) checks
     if (id_level < SS::IDtight) {
         // Common (across years) veto and fakable(loose) checks
@@ -22,6 +22,7 @@ bool SS::electronID(int idx, SS::IDLevel id_level, int year) {
         if (Electron_pt().at(idx) < 10.) { return false; }
         if (Electron_tightCharge().at(idx) != 2) { return false; }
         if (fabs(Electron_sip3d().at(idx)) >= 4) { return false; }
+        if (int(Electron_lostHits().at(idx)) > 0) { return false; }
     }
     // Year-specific checks
     switch (year) {
@@ -39,6 +40,7 @@ bool SS::electronID(int idx, SS::IDLevel id_level, int year) {
         return false;
         break;
     }
+    return false;
 }
 
 bool SS::electron2016ID(int idx, SS::IDLevel id_level) {
@@ -64,6 +66,7 @@ bool SS::electron2016ID(int idx, SS::IDLevel id_level) {
         return false;
         break;
     }
+    return false;
 }
 
 bool SS::electron2017ID(int idx, SS::IDLevel id_level) {
@@ -292,7 +295,6 @@ bool SS::passesElectronMVA(int idx, SS::ElectronMVAIDLevel id_level, int year) {
         return false;
         break;
     }
-
     return false;
 }
 

--- a/NanoCORE/MuonSelections.cc
+++ b/NanoCORE/MuonSelections.cc
@@ -4,15 +4,24 @@
 using namespace tas;
 
 bool SS::muonID(unsigned int idx, SS::IDLevel id_level, int year) {
-    // Common checks
-    if (Muon_pt().at(idx) < 10.) { return false; }
+    // Common (across years and ID levels) checks
+    if (Muon_pt().at(idx) < 5.) { return false; }
     if (fabs(Muon_eta().at(idx)) > 2.4) { return false; }
     if (fabs(Muon_dxy().at(idx)) > 0.05) { return false; }
     if (fabs(Muon_dz().at(idx)) > 0.1) { return false; }
-    if (fabs(Muon_sip3d().at(idx)) >= 4) { return false; }
-    if (!Muon_looseId().at(idx)) { return false; }
-    if (Muon_ptErr().at(idx) / Muon_pt().at(idx) >= 0.2) { return false; }
-    if (!Muon_mediumId().at(idx)) { return false; }
+    if (!Muon_looseId().at(idx)) { return false; } // loose POG ID
+    // Common (across years) checks
+    if (id_level < SS::IDtight) {
+        // Common (across years) veto and fakable(loose) checks
+        if (Muon_miniPFRelIso_all().at(idx) > 0.4) { return false; }
+    }
+    if (id_level > SS::IDveto) {
+        // Common (across years) fakable(loose) and tight checks
+        if (Muon_pt().at(idx) < 10.) { return false; }
+        if (fabs(Muon_sip3d().at(idx)) >= 4) { return false; }
+        if (!Muon_mediumId().at(idx)) { return false; } // medium POG ID
+        if (Muon_ptErr().at(idx) / Muon_pt().at(idx) >= 0.2) { return false; }
+    }
     switch (year) {
     case (2016):
         return muon2016ID(idx, id_level);
@@ -37,7 +46,6 @@ bool SS::muon2016ID(unsigned int idx, SS::IDLevel id_level) {
         return true;
         break;
     case (SS::IDfakable):
-        if (Muon_miniPFRelIso_all().at(idx) > 0.4) { return false; }
         return true;
         break;
     case (SS::IDtight):
@@ -59,7 +67,6 @@ bool SS::muon2017ID(unsigned int idx, SS::IDLevel id_level) {
         return true;
         break;
     case (SS::IDfakable):
-        if (Muon_miniPFRelIso_all().at(idx) > 0.4) { return false; }
         return true;
         break;
     case (SS::IDtight):
@@ -82,7 +89,6 @@ bool SS::muon2018ID(unsigned int idx, SS::IDLevel id_level) {
         break;
     case (SS::IDfakable):
         // Same as 2017 ID
-        if (Muon_miniPFRelIso_all().at(idx) > 0.4) { return false; }
         return true;
         break;
     case (SS::IDtight):

--- a/NanoCORE/SSSelections.h
+++ b/NanoCORE/SSSelections.h
@@ -4,6 +4,7 @@
 #include "Base.h"
 
 SS::IDLevel whichLeptonLevel(int id, int idx);
+bool isLeptonLevel(SS::IDLevel idlevel, int id, int idx);
 
 struct Lepton {
     Lepton(int id = 0, unsigned int idx = 0) : id_(id), idx_(idx) {
@@ -50,11 +51,10 @@ template <typename T1, typename T2> std::ostream &operator<<(std::ostream &os, s
     return os << "(" << p.first << ", " << p.second << ")";
 }
 
-vector<Lepton> getLeptons();
+Leptons getLeptons();
 std::tuple<int, int, float> getJetInfo(vector<Lepton> &leps, int variation = 0);
 std::pair<int, int> makesResonance(Leptons &leps, Lepton lep1, Lepton lep2, float mass, float window);
 std::pair<int, Hyp> getBestHyp(vector<Lepton> &leptons, bool verbose);
-bool isLeptonLevel(SS::IDLevel idlevel, int id, int idx);
 void dumpLeptonProperties(Lepton lep);
 
 #endif

--- a/NanoCORE/Tools/jetcorr/data/download_jecs.sh
+++ b/NanoCORE/Tools/jetcorr/data/download_jecs.sh
@@ -4,7 +4,7 @@
 
 baseurl="https://raw.githubusercontent.com/cms-jet/JECDatabase/master/textFiles/"
 
-era="Autumn18_V19_MC"
+era="Summer16_07Aug2017_V11_MC"
 
 jettypes="
 AK4PFchs


### PR DESCRIPTION
Synched against CMS4 SS veto IDs using the same framework as previous synch. In particular, ran lepton IDs on the same set of leptons from each of the same set of 290,100 NanoAOD and CMS4 events.

Muons:
- 105,358 reco muons pass Nano veto ID
- 105,397 reco muons pass CMS4 veto ID
= 39 muon difference

Electrons:
- 75,072 reco electrons pass Nano electron veto ID
- 75,124 reco electrons pass CMS4 electron veto ID
= 52 electron difference

Also validated that the tight and loose lepton yields match the previously presented synch (cf. these [slides](http://uaf-10.t2.ucsd.edu/~jguiang/presentations/ttbar/leptonIDs_07-17-2020.pdf)).

Also added a few miscellaneous fixes:
- Added some newer JEC info (I forget when we did this and for what, but should be correct)
- Some refactoring of SSSelections.h