### PR TITLE
Added ttH lepton IDs

### DIFF
--- a/NanoCORE/Base.h
+++ b/NanoCORE/Base.h
@@ -4,7 +4,7 @@
 namespace SS {
     enum IDLevel {
         IDdefault = -1,
-        IDveto = 0, // for Z-veto
+        IDveto = 0,
         IDfakableNoIso = 1,
         IDfakable = 2, // for fake background + jet cleaning
         IDtightNoIso = 3,
@@ -14,7 +14,7 @@ namespace SS {
 
 namespace ttH {
     enum IDLevel {
-        IDveto = 0, // for Z-veto
+        IDveto = 0,
         IDfakable = 1, // for fake background + jet cleaning
         IDtight = 2 // for analysis
     };

--- a/NanoCORE/Base.h
+++ b/NanoCORE/Base.h
@@ -12,4 +12,12 @@ namespace SS {
     };
 }
 
+namespace ttH {
+    enum IDLevel {
+        IDveto = 0, // for Z-veto
+        IDfakable = 1, // for fake background + jet cleaning
+        IDtight = 2 // for analysis
+    };
+}
+
 #endif

--- a/NanoCORE/ElectronSelections.cc
+++ b/NanoCORE/ElectronSelections.cc
@@ -362,7 +362,7 @@ bool ttH::isTriggerSafeNoIso(int idx) {
     // Calculate absolute value of supercluster eta
     float SC_absEta = fabs(Electron_eta().at(idx) + Electron_deltaEtaSC().at(idx));
     if (Electron_hoe().at(idx) >= 0.1) { return false; }
-    if (fabs(Electron_eInvMinusPInv().at(idx)) <= -0.4) { return false; }
+    if (Electron_eInvMinusPInv().at(idx) <= -0.4) { return false; }
     if (SC_absEta <= 1.479) {
         // Barrel
         if (Electron_sieie().at(idx) >= 0.011) { return false; }

--- a/NanoCORE/ElectronSelections.cc
+++ b/NanoCORE/ElectronSelections.cc
@@ -316,11 +316,11 @@ bool SS::isTriggerSafeNoIso(int idx) {
 
 bool ttH::electronID(int idx, ttH::IDLevel id_level, int year) {
     // Common (across ID levels) checks
-    if (Electron_pt().at(idx) <= 7.) { return false; } // cone pt? FIXME if not!
+    if (Electron_pt().at(idx) <= 7.) { return false; }
     if (fabs(Electron_eta().at(idx) + Electron_deltaEtaSC().at(idx)) >= 2.5) { return false; }
     if (fabs(Electron_dxy().at(idx)) >= 0.05) { return false; }
     if (fabs(Electron_dz().at(idx)) >= 0.1) { return false; }
-    if (Electron_sip3d().at(idx) >= 8) { return false; } // d/sigma_d? FIXME if not!
+    if (Electron_sip3d().at(idx) >= 8) { return false; }
     if (Electron_miniPFRelIso_all().at(idx) >= 0.4) { return false; }
     if (int(Electron_lostHits().at(idx)) > 1) { return false; }
     if (!Electron_mvaFall17V2Iso_WPL().at(idx)) { return false; }

--- a/NanoCORE/ElectronSelections.cc
+++ b/NanoCORE/ElectronSelections.cc
@@ -1,12 +1,13 @@
 #include "ElectronSelections.h"
 #include "IsolationTools.h"
+#include "Config.h"
 
 using namespace tas;
 
 bool SS::electronID(int idx, SS::IDLevel id_level, int year) {
     // Common (across years and ID levels) checks
     if (Electron_pt().at(idx) < 7.) { return false; }
-    if (!isTriggerSafeNoIso(idx)) { return false; }
+    if (!SS::isTriggerSafeNoIso(idx)) { return false; }
     if (fabs(Electron_eta().at(idx) + Electron_deltaEtaSC().at(idx)) > 2.5) { return false; }
     if (!Electron_convVeto().at(idx)) { return false; }
     if (fabs(Electron_dxy().at(idx)) >= 0.05) { return false; }
@@ -298,7 +299,7 @@ bool SS::passesElectronMVA(int idx, SS::ElectronMVAIDLevel id_level, int year) {
     return false;
 }
 
-bool isTriggerSafeNoIso(int idx) {
+bool SS::isTriggerSafeNoIso(int idx) {
     // Calculate absolute value of supercluster eta
     float SC_absEta = fabs(Electron_eta().at(idx) + Electron_deltaEtaSC().at(idx));
     if (SC_absEta <= 1.479) {
@@ -309,6 +310,65 @@ bool isTriggerSafeNoIso(int idx) {
         if (Electron_sieie().at(idx) >= 0.031) { return false; }
         if (Electron_hoe().at(idx) >= 0.08) { return false; }
         if (fabs(Electron_eInvMinusPInv().at(idx)) >= 0.01) { return false; }
+    }
+    return true;
+}
+
+bool ttH::electronID(int idx, ttH::IDLevel id_level, int year) {
+    // Common (across ID levels) checks
+    if (Electron_pt().at(idx) <= 7.) { return false; } // cone pt? FIXME if not!
+    if (fabs(Electron_eta().at(idx) + Electron_deltaEtaSC().at(idx)) >= 2.5) { return false; }
+    if (fabs(Electron_dxy().at(idx)) >= 0.05) { return false; }
+    if (fabs(Electron_dz().at(idx)) >= 0.1) { return false; }
+    if (Electron_sip3d().at(idx) >= 8) { return false; } // d/sigma_d? FIXME if not!
+    if (Electron_miniPFRelIso_all().at(idx) >= 0.4) { return false; }
+    if (int(Electron_lostHits().at(idx)) > 1) { return false; }
+    if (!Electron_mvaFall17V2Iso_WPL().at(idx)) { return false; }
+    // Common fakable(loose) and tight checks
+    if (id_level > ttH::IDveto) {
+        if (Electron_pt().at(idx) <= 10.) { return false; }
+        if (!ttH::isTriggerSafeNoIso(idx)) { return false; }
+        if (!Electron_convVeto().at(idx)) { return false; }
+        if (int(Electron_lostHits().at(idx)) > 0) { return false; }
+        unsigned int jet_idx = Electron_jetIdx().at(idx);
+        if (Jet_btagDeepFlavB().at(jet_idx) >= gconf.WP_DeepFlav_medium) { return false; };
+        return true;
+    }
+    switch (id_level) {
+    case (ttH::IDveto):
+        return true;
+        break;
+    case (ttH::IDfakable):
+        if (Electron_mvaTTH().at(idx) <= 0.8) { 
+            if (!Electron_mvaFall17V2Iso_WP80().at(idx)) { return false; }
+            if (Electron_jetRelIso().at(idx) >= 0.7) { return false; }
+        }
+        return true;
+        break;
+    case (ttH::IDtight):
+        if (Electron_mvaTTH().at(idx) <= 0.8) { return false; }
+        return true;
+        break;
+    default:
+        throw std::runtime_error("ElectronSelections.cc: ERROR - invalid ID level");
+        return false;
+        break;
+    }
+
+    return true;
+}
+
+bool ttH::isTriggerSafeNoIso(int idx) {
+    // Calculate absolute value of supercluster eta
+    float SC_absEta = fabs(Electron_eta().at(idx) + Electron_deltaEtaSC().at(idx));
+    if (Electron_hoe().at(idx) >= 0.1) { return false; }
+    if (fabs(Electron_eInvMinusPInv().at(idx)) <= -0.4) { return false; }
+    if (SC_absEta <= 1.479) {
+        // Barrel
+        if (Electron_sieie().at(idx) >= 0.011) { return false; }
+    } else if (SC_absEta > 1.479 && SC_absEta < 2.5) {
+        // Endcaps
+        if (Electron_sieie().at(idx) >= 0.030) { return false; }
     }
     return true;
 }

--- a/NanoCORE/ElectronSelections.h
+++ b/NanoCORE/ElectronSelections.h
@@ -22,8 +22,12 @@ namespace SS {
     bool electron2017ID(int idx, SS::IDLevel id_level);
     bool electron2018ID(int idx, SS::IDLevel id_level);
     bool passesElectronMVA(int idx, SS::ElectronMVAIDLevel id_level, int year);
+    bool isTriggerSafeNoIso(int idx);
 }
 
-bool isTriggerSafeNoIso(int idx);
+namespace ttH {
+    bool electronID(int idx, ttH::IDLevel id_level, int year);
+    bool isTriggerSafeNoIso(int idx);
+}
 
 #endif

--- a/NanoCORE/MuonSelections.cc
+++ b/NanoCORE/MuonSelections.cc
@@ -107,11 +107,11 @@ bool SS::muon2018ID(unsigned int idx, SS::IDLevel id_level) {
 
 bool ttH::muonID(unsigned int idx, ttH::IDLevel id_level, int year) {
     // Common (across ID levels) checks
-    if (Muon_pt().at(idx) <= 5.) { return false; } // cone pt? FIXME if not!
+    if (Muon_pt().at(idx) <= 5.) { return false; }
     if (fabs(Muon_eta().at(idx)) >= 2.4) { return false; }
     if (fabs(Muon_dxy().at(idx)) >= 0.05) { return false; }
     if (fabs(Muon_dz().at(idx)) >= 0.1) { return false; }
-    if (Muon_sip3d().at(idx) >= 8) { return false; } // d/sigma_d? FIXME if not!
+    if (Muon_sip3d().at(idx) >= 8) { return false; }
     if (Muon_miniPFRelIso_all().at(idx) >= 0.4) { return false; }
     if (!Muon_looseId().at(idx)) { return false; } // loose POG ID
     // Common fakable(loose) and tight checks

--- a/NanoCORE/MuonSelections.cc
+++ b/NanoCORE/MuonSelections.cc
@@ -1,5 +1,6 @@
 #include "MuonSelections.h"
 #include "IsolationTools.h"
+#include "Config.h"
 
 using namespace tas;
 
@@ -102,4 +103,42 @@ bool SS::muon2018ID(unsigned int idx, SS::IDLevel id_level) {
         break;
     }
     return false;
+}
+
+bool ttH::muonID(unsigned int idx, ttH::IDLevel id_level, int year) {
+    // Common (across ID levels) checks
+    if (Muon_pt().at(idx) <= 5.) { return false; } // cone pt? FIXME if not!
+    if (fabs(Muon_eta().at(idx)) >= 2.4) { return false; }
+    if (fabs(Muon_dxy().at(idx)) >= 0.05) { return false; }
+    if (fabs(Muon_dz().at(idx)) >= 0.1) { return false; }
+    if (Muon_sip3d().at(idx) >= 8) { return false; } // d/sigma_d? FIXME if not!
+    if (Muon_miniPFRelIso_all().at(idx) >= 0.4) { return false; }
+    if (!Muon_looseId().at(idx)) { return false; } // loose POG ID
+    // Common fakable(loose) and tight checks
+    if (id_level > ttH::IDveto) {
+        if (Muon_pt().at(idx) <= 10.) { return false; }
+        unsigned int jet_idx = Muon_jetIdx().at(idx);
+        if (Jet_btagDeepFlavB().at(jet_idx) >= gconf.WP_DeepFlav_medium) { return false; };
+    }
+    switch (id_level) {
+    case (ttH::IDveto):
+        return true;
+        break;
+    case (ttH::IDfakable):
+        if (Muon_mvaTTH().at(idx) <= 0.85) { 
+            if (Muon_jetRelIso().at(idx) >= 0.5) { return false; }
+        }
+        return true;
+        break;
+    case (ttH::IDtight):
+        if (!Muon_mediumId().at(idx)) { return false; } // medium POG ID
+        if (Muon_mvaTTH().at(idx) <= 0.85) { return false; }
+        return true;
+        break;
+    default:
+        throw std::runtime_error("MuonSelections.cc: ERROR - invalid ID level");
+        return false;
+        break;
+    }
+    return true;
 }

--- a/NanoCORE/MuonSelections.h
+++ b/NanoCORE/MuonSelections.h
@@ -10,4 +10,8 @@ namespace SS {
     bool muon2018ID(unsigned int idx, SS::IDLevel id_level);
 }
 
+namespace ttH {
+    bool muonID(unsigned int idx, ttH::IDLevel id_level, int year);
+}
+
 #endif

--- a/NanoCORE/TauSelections.cc
+++ b/NanoCORE/TauSelections.cc
@@ -61,6 +61,37 @@ bool SS::tau2018ID(int idx, SS::IDLevel id_level)
     return SS::tau2017ID(idx, id_level); 
 }
 
+bool ttH::tauID(int idx, ttH::IDLevel id_level, int year) 
+{
+    if (Tau_pt().at(idx) <= 20.) { return false; }
+    if (fabs(Tau_dz().at(idx)) >= 0.2) { return false; }
+    if (fabs(Tau_eta().at(idx)) >= 2.3) { return false; }
+    if (!Tau_idDecayModeNewDMs().at(idx)) { return false; }
+    switch(id_level) 
+    {
+    case (ttH::IDveto):
+        if (!passesDeepTau(idx, DeepTau::vvLoose, DeepTau::vsJets)) { return false; }
+        return true;
+        break;
+    case (ttH::IDfakable):
+        if (!passesDeepTau(idx, DeepTau::vvLoose, DeepTau::vsJets)) { return false; }
+        if (!passesDeepTau(idx, DeepTau::vLoose, DeepTau::vsMuons)) { return false; }
+        if (!passesDeepTau(idx, DeepTau::vvvLoose, DeepTau::vsElectrons)) { return false; }
+        return true;
+        break;
+    case (ttH::IDtight):
+        if (!passesDeepTau(idx, DeepTau::tight, DeepTau::vsJets)) { return false; }
+        if (!passesDeepTau(idx, DeepTau::vLoose, DeepTau::vsMuons)) { return false; }
+        if (!passesDeepTau(idx, DeepTau::vvvLoose, DeepTau::vsElectrons)) { return false; }
+        return true;
+        break;
+    default:
+        throw std::runtime_error("TauSelections.cc: ERROR - invalid ID level");
+        return false;
+        break;
+    }
+}
+
 bool passesDeepTau(int idx, DeepTau::IDLevel id_level, DeepTau::Variant variant) 
 {
     int bit_flag;

--- a/NanoCORE/TauSelections.h
+++ b/NanoCORE/TauSelections.h
@@ -11,6 +11,10 @@ namespace SS {
     bool tau2018ID(int idx, SS::IDLevel id_level);
 }
 
+namespace ttH {
+    bool tauID(int idx, ttH::IDLevel id_level, int year);
+}
+
 namespace DeepTau {
     enum IDLevel {
         vvvLoose,


### PR DESCRIPTION
Should be checked for accuracy:
- Based on [this](https://cms.cern.ch/iCMS/jsp/db_notes/noteInfo.jsp?cmsnoteid=CMS%20AN-2019/111) AN (v14)
- Electron ID: Table 20 (pg. 30)
- Muon ID: Table 21 (pg. 31)
- Tau ID: Table 22 (pg. 32)