### PR TITLE
JERs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,4 +15,4 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - run: cd NanoCORE && make testpy3 -j8
+    - run: cd NanoCORE && mv MakefileCI Makefile && make testpy3 -j8

--- a/NanoCORE/Config.cc
+++ b/NanoCORE/Config.cc
@@ -114,6 +114,8 @@ void GlobalConfig::GetConfigs(int in_year) {
         jecEraG = jecEraH = "Summer19UL16APV_RunBCDEF_V7_DATA";
         jecEraMC = "Summer19UL16APV_V7_MC";
 
+        jerEra = "Summer20UL16APV_JRV3_MC";
+
         // B-tag working points
         // https://twiki.cern.ch/twiki/bin/view/CMS/BtagRecommendation106XUL16preVFP
         WP_DeepFlav_tight = 0.6502;
@@ -138,6 +140,8 @@ void GlobalConfig::GetConfigs(int in_year) {
         jecEraE = jecEraF = "Summer19UL16_RunBCDEFGH_Combined_V7_DATA";
         jecEraG = jecEraH = "Summer19UL16_RunBCDEFGH_Combined_V7_DATA";
         jecEraMC = "Summer19UL16_V7_MC";
+
+        jerEra = "Summer20UL16_JRV3_MC";
 
         // B-tag working points
         // https://twiki.cern.ch/twiki/bin/view/CMS/BtagRecommendation106XUL16postVFP
@@ -190,6 +194,8 @@ void GlobalConfig::GetConfigs(int in_year) {
         jecEraF = "Summer19UL17_RunF_V5_DATA";
         // https://twiki.cern.ch/twiki/bin/viewauth/CMS/JECDataMC#Recommended_for_MC
         jecEraMC = "Summer19UL17_V5_MC";
+
+        jerEra = "Summer19UL17_JRV2_MC";
 
         // B-tag working points
         // https://twiki.cern.ch/twiki/bin/view/CMS/BtagRecommendation106XUL17
@@ -246,6 +252,8 @@ void GlobalConfig::GetConfigs(int in_year) {
         jecEraC = "Summer19UL18_RunC_V5_DATA";
         jecEraD = "Summer19UL18_RunD_V5_DATA";
         jecEraMC = "Summer19UL18_V5_MC";
+
+        jerEra = "Summer19UL18_JRV2_MC";
 
         // B-tag working points
         // https://twiki.cern.ch/twiki/bin/view/CMS/BtagRecommendation106XUL18#AK4_b_tagging

--- a/NanoCORE/Config.h
+++ b/NanoCORE/Config.h
@@ -36,6 +36,8 @@ class GlobalConfig {
     std::string jecEraH;
     std::string jecEraMC;
 
+    std::string jerEra;
+
     //_________________________________
     // B-tag working points
     float WP_DeepFlav_tight = -1;

--- a/NanoCORE/Makefile
+++ b/NanoCORE/Makefile
@@ -9,7 +9,7 @@ $(LIB): $(OBJECTS)
 	ln -sf $(LIB) lib$(LIB)
 
 %.o:	%.cc
-	$(CXX) $(CXXFLAGS) -c $< -o $@ -fno-var-tracking
+	$(CXX) $(CXXFLAGS) -I${CMSSW_BASE}/../../../external/boost/1.67.0/include -I${CMSSW_BASE}/src -c $< -o $@ -fno-var-tracking
 
 test: all
 	python Tools/unit_tests/tests.py

--- a/NanoCORE/Makefile
+++ b/NanoCORE/Makefile
@@ -1,6 +1,6 @@
 include Makefile.arch
 
-SOURCES=$(wildcard *.cc) $(wildcard Tools/*.cc) $(wildcard Tools/btagsf/*.cc)
+SOURCES=$(wildcard *.cc) $(wildcard Tools/*.cc) $(wildcard Tools/btagsf/*.cc) $(wildcard Tools/jetcorr/PhysicsTools/NanoAODTools/src/*.cc)
 OBJECTS=$(SOURCES:.cc=.o)
 LIB=NANO_CORE.so
 

--- a/NanoCORE/MakefileCI
+++ b/NanoCORE/MakefileCI
@@ -1,0 +1,28 @@
+include Makefile.arch
+
+SOURCES=$(wildcard *.cc) $(wildcard Tools/*.cc) $(wildcard Tools/btagsf/*.cc)
+OBJECTS=$(SOURCES:.cc=.o)
+LIB=NANO_CORE.so
+
+$(LIB): $(OBJECTS) 
+	$(LD) $(LDFLAGS) $(SOFLAGS) $(OBJECTS) $(ROOTLIBS) -lTMVA -lEG -lGenVector -lXMLIO -lMLP -lTreePlayer -o $@
+	ln -sf $(LIB) lib$(LIB)
+
+%.o:	%.cc
+	$(CXX) $(CXXFLAGS) -c $< -o $@ -fno-var-tracking
+
+test: all
+	python Tools/unit_tests/tests.py
+
+testpy3: all
+	python3 Tools/unit_tests/tests.py
+
+all: $(LIB) 
+clean:
+	rm -f *.o \
+	rm -f *.d \
+	rm -f *.so \
+	rm -f Tools/*.o \
+	rm -f Tools/*.d \
+	rm -f Tools/*.so
+

--- a/NanoCORE/Nano.h
+++ b/NanoCORE/Nano.h
@@ -29,7 +29,7 @@ typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> > LorentzVector
 #define NLHESCALEWEIGHT_MAX 30 // for LHEScaleWeight_* collection
 #define NCORRT1METJET_MAX 102 // for CorrT1METJet_* collection
 #define NMUON_MAX 90 // for Muon_* collection
-#define NGENJET_MAX 60 // for GenJet_* collection
+#define NGENJET_MAX 250 // for GenJet_* collection
 #define NPSWEIGHT_MAX 15 // for PSWeight_* collection
 #define NBOOSTEDTAU_MAX 12 // for boostedTau_* collection
 #define NLHEPART_MAX 24 // for LHEPart_* collection

--- a/NanoCORE/Tools/jetcorr/JetResolutionUncertainty.h
+++ b/NanoCORE/Tools/jetcorr/JetResolutionUncertainty.h
@@ -1,0 +1,86 @@
+#ifndef JetResolutionUncertainty_h
+#define JetResolutionUncertainty_h
+
+#include "PhysicsTools/NanoAODTools/interface/PyJetParametersWrapper.h"
+#include "PhysicsTools/NanoAODTools/interface/PyJetResolutionScaleFactorWrapper.h"
+#include "PhysicsTools/NanoAODTools/interface/PyJetResolutionWrapper.h"
+
+#include "TLorentzVector.h"
+#include "TRandom3.h"
+
+#include <string>
+
+class JetResolutionUncertainty
+{
+  private:
+    PyJetParametersWrapper params;
+
+    JME::JetResolution resolutions;
+    JME::JetResolutionScaleFactor scaleFactors;
+
+    float getResolution() { return resolutions.getResolution(params); }
+    float getScaleFactor(Variation fVariation) { return scaleFactors.getScaleFactor(params, fVariation); }
+
+  public:
+    JetResolutionUncertainty() {
+      resolutions = PyJetResolutionWrapper();
+      scaleFactors = PyJetResolutionScaleFactorWrapper();
+    }
+    JetResolutionUncertainty(const std::string& fJERInputFullPath, const std::string& fJERUncInputFullPath) {
+      resolutions = PyJetResolutionWrapper(fJERInputFullPath);
+      scaleFactors = PyJetResolutionScaleFactorWrapper(fJERUncInputFullPath);
+    }
+    ~JetResolutionUncertainty() {};
+
+    void setJetEta(float fEta) { params.setJetEta(fEta); }
+    void setJetPt(float fPt) { params.setJetPt(fPt); }
+    void setRho(float fRho) { params.setRho(fRho); }
+
+    void applyJER(LorentzVector &jet_p4, const int JERUnc, const std::vector<LorentzVector> &GenJet_p4, TRandom3 &rnd) {
+      // JERUnc == 1 means the nominal value is applied, +/-2 means a variation is applied, anything else means JERs are not applied.
+      // rnd is a pseudo-number generator, initialized outside the analysis looper.
+      // At the start of each event, its seed needs to be set to:
+      // ( 1 + ( nt.run() << 20 ) + ( nt.luminosityBlock() << 10 ) + nt.event() + ( nt.nJet() > 0 ? nt.Jet_eta().at(0) / 0.01 : 0 ) )
+
+      float jerSF, smearFactor = 1.0;
+      if ( JERUnc == 1 ) jerSF = getScaleFactor(Variation::NOMINAL);
+      else if ( JERUnc == 2 ) jerSF = getScaleFactor(Variation::UP);
+      else if ( JERUnc ==-2 ) jerSF = getScaleFactor(Variation::DOWN);
+      else return;
+
+      int genJet_idx=-1;
+      float drmin = 1e9;
+      for ( unsigned int igenjet=0; igenjet < GenJet_p4.size(); igenjet++ ) {
+        float deta = GenJet_p4[igenjet].Eta() - jet_p4.Eta();
+        float dphi = TVector2::Phi_mpi_pi(GenJet_p4[igenjet].Phi() - jet_p4.Phi());
+        float dr = TMath::Sqrt( deta*deta+dphi*dphi );
+        if ( dr < drmin ) {
+          drmin = dr;
+          genJet_idx = igenjet;
+        }
+      }
+
+      if ( drmin < 0.4 ) {
+        float dPt = jet_p4.Pt() - GenJet_p4[genJet_idx].Pt();
+
+        float smearFactor = ( 1.0 + ( jerSF - 1.0 ) * dPt / jet_p4.Pt() );
+      }
+      else {
+        float jerRes = getResolution();
+
+        float rand = rnd.Gaus(0, jerRes);
+        if ( jerSF > 1. ) {
+          smearFactor = ( 1.0 + rand * TMath::Sqrt( jerSF*jerSF - 1.0 ) );
+        }
+        else {
+          smearFactor = 1.0;
+        }
+      }
+
+      if ( smearFactor * jet_p4.E() < 1e-2 ) smearFactor = 1e-2 / jet_p4.E();
+
+      jet_p4 *= smearFactor;
+    }
+};
+
+#endif

--- a/NanoCORE/Tools/jetcorr/PhysicsTools/NanoAODTools/interface/PyJetParametersWrapper.h
+++ b/NanoCORE/Tools/jetcorr/PhysicsTools/NanoAODTools/interface/PyJetParametersWrapper.h
@@ -1,0 +1,16 @@
+#ifndef PhysicsTools_NanoAODTools_PyJetParametersWrapper_h
+#define PhysicsTools_NanoAODTools_PyJetParametersWrapper_h
+
+#include "CondFormats/JetMETObjects/interface/JetResolutionObject.h"
+
+#include <string>
+
+class PyJetParametersWrapper : public JME::JetParameters
+{
+ public:
+  PyJetParametersWrapper();
+  //PyJetParametersWrapper(const PyJetParametersWrapper& rhs);
+  PyJetParametersWrapper(std::initializer_list<typename value_type::value_type> init);
+};
+
+#endif

--- a/NanoCORE/Tools/jetcorr/PhysicsTools/NanoAODTools/interface/PyJetResolutionScaleFactorWrapper.h
+++ b/NanoCORE/Tools/jetcorr/PhysicsTools/NanoAODTools/interface/PyJetResolutionScaleFactorWrapper.h
@@ -1,0 +1,18 @@
+#ifndef PhysicsTools_NanoAODTools_PyJetResolutionScaleFactorWrapper_h
+#define PhysicsTools_NanoAODTools_PyJetResolutionScaleFactorWrapper_h
+
+#include "JetMETCorrections/Modules/interface/JetResolution.h"
+
+#include "CondFormats/JetMETObjects/interface/JetResolutionObject.h"
+
+#include <string>
+
+class PyJetResolutionScaleFactorWrapper : public JME::JetResolutionScaleFactor
+{
+ public:
+  PyJetResolutionScaleFactorWrapper(const std::string& filename);
+  PyJetResolutionScaleFactorWrapper(const JME::JetResolutionObject& object);
+  PyJetResolutionScaleFactorWrapper();
+};
+
+#endif

--- a/NanoCORE/Tools/jetcorr/PhysicsTools/NanoAODTools/interface/PyJetResolutionWrapper.h
+++ b/NanoCORE/Tools/jetcorr/PhysicsTools/NanoAODTools/interface/PyJetResolutionWrapper.h
@@ -1,0 +1,18 @@
+#ifndef PhysicsTools_NanoAODTools_PyJetResolutionWrapper_h
+#define PhysicsTools_NanoAODTools_PyJetResolutionWrapper_h
+
+#include "JetMETCorrections/Modules/interface/JetResolution.h"
+
+#include "CondFormats/JetMETObjects/interface/JetResolutionObject.h"
+
+#include <string>
+
+class PyJetResolutionWrapper : public JME::JetResolution
+{
+ public:
+  PyJetResolutionWrapper(const std::string& filename);
+  PyJetResolutionWrapper(const JME::JetResolutionObject& object);
+  PyJetResolutionWrapper();
+};
+
+#endif

--- a/NanoCORE/Tools/jetcorr/PhysicsTools/NanoAODTools/src/PyJetParametersWrapper.cc
+++ b/NanoCORE/Tools/jetcorr/PhysicsTools/NanoAODTools/src/PyJetParametersWrapper.cc
@@ -1,0 +1,15 @@
+#include "PhysicsTools/NanoAODTools/interface/PyJetParametersWrapper.h"
+
+#include <algorithm>
+
+PyJetParametersWrapper::PyJetParametersWrapper()
+  : JME::JetParameters()
+{}
+
+//PyJetParametersWrapper::PyJetParametersWrapper(const PyJetParametersWrapper& rhs)
+//  : JME::JetParameters(rhs)
+//{}
+
+PyJetParametersWrapper::PyJetParametersWrapper(std::initializer_list<typename value_type::value_type> init)
+  : JME::JetParameters(init)
+{}

--- a/NanoCORE/Tools/jetcorr/PhysicsTools/NanoAODTools/src/PyJetParametersWrapper.cc
+++ b/NanoCORE/Tools/jetcorr/PhysicsTools/NanoAODTools/src/PyJetParametersWrapper.cc
@@ -1,4 +1,4 @@
-#include "PhysicsTools/NanoAODTools/interface/PyJetParametersWrapper.h"
+#include "../interface/PyJetParametersWrapper.h"
 
 #include <algorithm>
 

--- a/NanoCORE/Tools/jetcorr/PhysicsTools/NanoAODTools/src/PyJetResolutionScaleFactorWrapper.cc
+++ b/NanoCORE/Tools/jetcorr/PhysicsTools/NanoAODTools/src/PyJetResolutionScaleFactorWrapper.cc
@@ -1,0 +1,13 @@
+#include "PhysicsTools/NanoAODTools/interface/PyJetResolutionScaleFactorWrapper.h"
+
+PyJetResolutionScaleFactorWrapper::PyJetResolutionScaleFactorWrapper(const std::string& filename)
+   : JME::JetResolutionScaleFactor(filename)
+{}
+ 
+PyJetResolutionScaleFactorWrapper::PyJetResolutionScaleFactorWrapper(const JME::JetResolutionObject& object)
+  : JME::JetResolutionScaleFactor(object)
+{}
+
+PyJetResolutionScaleFactorWrapper::PyJetResolutionScaleFactorWrapper()
+  : JME::JetResolutionScaleFactor()
+{}

--- a/NanoCORE/Tools/jetcorr/PhysicsTools/NanoAODTools/src/PyJetResolutionScaleFactorWrapper.cc
+++ b/NanoCORE/Tools/jetcorr/PhysicsTools/NanoAODTools/src/PyJetResolutionScaleFactorWrapper.cc
@@ -1,4 +1,4 @@
-#include "PhysicsTools/NanoAODTools/interface/PyJetResolutionScaleFactorWrapper.h"
+#include "../interface/PyJetResolutionScaleFactorWrapper.h"
 
 PyJetResolutionScaleFactorWrapper::PyJetResolutionScaleFactorWrapper(const std::string& filename)
    : JME::JetResolutionScaleFactor(filename)

--- a/NanoCORE/Tools/jetcorr/PhysicsTools/NanoAODTools/src/PyJetResolutionWrapper.cc
+++ b/NanoCORE/Tools/jetcorr/PhysicsTools/NanoAODTools/src/PyJetResolutionWrapper.cc
@@ -1,0 +1,13 @@
+#include "PhysicsTools/NanoAODTools/interface/PyJetResolutionWrapper.h"
+
+PyJetResolutionWrapper::PyJetResolutionWrapper(const std::string& filename)
+   : JME::JetResolution(filename)
+{}
+ 
+PyJetResolutionWrapper::PyJetResolutionWrapper(const JME::JetResolutionObject& object)
+  : JME::JetResolution(object)
+{}
+
+PyJetResolutionWrapper::PyJetResolutionWrapper()
+  : JME::JetResolution()
+{}

--- a/NanoCORE/Tools/jetcorr/PhysicsTools/NanoAODTools/src/PyJetResolutionWrapper.cc
+++ b/NanoCORE/Tools/jetcorr/PhysicsTools/NanoAODTools/src/PyJetResolutionWrapper.cc
@@ -1,4 +1,4 @@
-#include "PhysicsTools/NanoAODTools/interface/PyJetResolutionWrapper.h"
+#include "../interface/PyJetResolutionWrapper.h"
 
 PyJetResolutionWrapper::PyJetResolutionWrapper(const std::string& filename)
    : JME::JetResolution(filename)

--- a/NanoCORE/Tools/jetcorr/data/download_jers.sh
+++ b/NanoCORE/Tools/jetcorr/data/download_jers.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+
+# url is like https://raw.githubusercontent.com/cms-jet/JRDatabase/master/textFiles/Summer19UL18_JRV2_MC/Summer19UL18_JRV2_MC_PtResolution_AK4PFchs.txt
+
+baseurl="https://raw.githubusercontent.com/cms-jet/JRDatabase/master/textFiles/"
+
+eras="
+Summer20UL16APV_JRV3_MC
+Summer20UL16_JRV3_MC
+Summer19UL17_JRV2_MC
+Summer19UL18_JRV2_MC
+"
+
+jettypes="
+AK4PFchs
+"
+
+corrstrs="
+PtResolution
+SF
+"
+
+for era in $eras; do
+    mkdir -p $era
+
+    cd $era
+    for jettype in $jettypes; do
+        for corrstr in $corrstrs; do
+            echo Executing: curl -s -L "$baseurl/$era/${era}_${corrstr}_${jettype}.txt"
+            curl -s -O -L "$baseurl/$era/${era}_${corrstr}_${jettype}.txt"
+        done
+    done
+    cd -
+done


### PR DESCRIPTION
This PR includes an implementation of applying the JER corrections and uncertainties on jets, taken from NanoAODTools.

The JER tags (for UL samples) used for the resolution and the SFs are included in the NanoCORE configuration and there is a script to download the relevant .txt files locally.

The JetResolutionUncertainty class takes care of calculating and applying the corrections and uncertainties, with an example application shown [here](https://github.com/cmstas/ZPrimeSnT/blob/d853694b52ee271366621c00e9e43b03c363bf0c/cpp/ScanChain_Zp.C#L474). The class relies on a few NanoAODTools files, which are now included in the PR, and some CMSSW packages, which are kept as external. To account for that, the Makefile was modified.

Finally, the size of the GenJet array was increased to avoid crashes.